### PR TITLE
fix: fix release-only entity flattening from dangling Eigen expression

### DIFF
--- a/include/igesio/graphics/core/entity_graphics.h
+++ b/include/igesio/graphics/core/entity_graphics.h
@@ -252,7 +252,11 @@ class EntityGraphics : public IEntityGraphics {
             auto ptr = std::dynamic_pointer_cast<const entities::EntityBase>(entity_);
             if (ptr) {
                 // entity_が参照する変換行列を掛け合わせる
-                auto entity_transform = ptr->GetTransformationMatrix()
+                // NOTE: cast<float>()は遅延評価式を返すため、autoで受けると
+                //       GetTransformation()が返す一時Matrix4dへのダングリング参照
+                //       となる (Release最適化時にUBで描画が破綻する)。具体型で
+                //       受けて一時が生存中に即時評価・コピーさせる。
+                const igesio::Matrix4f entity_transform = ptr->GetTransformationMatrix()
                         .GetTransformation().template cast<float>();
                 return world_transform_ * entity_transform;
             }

--- a/src/graphics/surfaces/trimmed_surface_graphics.cpp
+++ b/src/graphics/surfaces/trimmed_surface_graphics.cpp
@@ -57,12 +57,15 @@ std::optional<std::array<float, 8>> ComputeVertexData(
     auto deriv_opt = entity.TryGetDerivatives(u, v, 1);
     if (!deriv_opt) return std::nullopt;
 
-    auto pos = (*deriv_opt)(0, 0).cast<float>();
+    // NOTE: cast<float>()は遅延評価式を返すため、autoで受けると一時オブジェクト
+    //       へのダングリング参照となる。具体型で受けて即時評価・コピーさせる。
+    const igesio::Vector3f pos = (*deriv_opt)(0, 0).cast<float>();
     const Vector3d su = (*deriv_opt)(1, 0);
     const Vector3d sv = (*deriv_opt)(0, 1);
     const Vector3d n_vec = su.cross(sv);
     const double len = n_vec.norm();
-    auto normal = ((len > 1e-10) ? (n_vec / len) : Vector3d(0, 0, 1)).cast<float>();
+    const igesio::Vector3f normal =
+            ((len > 1e-10) ? (n_vec / len) : Vector3d(0, 0, 1)).cast<float>();
 
     const float tu = static_cast<float>((u - u_range[0]) /
                                         (u_range[1] - u_range[0]));


### PR DESCRIPTION
In release builds, nearly all curve and surface entities were rendered collapsed onto an x=c plane (c being the x-component of the entity's transformation matrix translation, or 0 for entities without one). Debug builds were unaffected.

The root cause was an `auto` variable holding an Eigen expression template that referenced a destroyed temporary:

```
auto entity_transform = ptr->GetTransformationMatrix()
        .GetTransformation().template cast<float>();
```

`GetTransformation()` returns a temporary `Matrix4d`, and `.cast<float>()` returns a lazy `CwiseUnaryOp` that references it. Storing the result in `auto` leaves a dangling reference once the temporary is destroyed at the end of the statement, so the subsequent `world_transform_ * entity_transform` reads freed stack memory. Debug builds happened to leave the stack intact, while release optimizations reused the slot and corrupted the model matrix.

- Receive the cast result as a concrete `Matrix4f` in `EntityGraphics::GetWorldTransform()`, forcing evaluation while the temporary is still alive. This fixes the flattening for every entity whose graphics class uses `use_entity_transform_ == true`.
- Apply the same fix to the position and normal casts in `TrimmedSurfaceGraphics::ComputeVertexData`, which had the identical dangling-reference pattern.