### PR TITLE
perf: speed up the IGES read pipeline end-to-end without changing results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,11 @@ option(IGESIO_ENABLE_COVERAGE "Enable coverage reporting" OFF)
 # Coverage configuration
 if(IGESIO_ENABLE_COVERAGE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(--coverage)
+        # -fprofile-update=atomic makes gcov counter increments atomic, which is
+        # required because the read pipeline runs instrumented code on multiple
+        # threads; the default (single) update mode races and produces corrupted
+        # (negative) counts that lcov/geninfo rejects.
+        add_compile_options(--coverage -fprofile-update=atomic)
         add_link_options(--coverage)
         message(STATUS "Coverage reporting enabled")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ project(IGESio VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Threads (std::thread/std::async backend for igesio/common/parallel.h).
+# Links pthread on Linux (GCC/Clang); a no-op on MSVC and macOS.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # Option to enable coverage
 option(IGESIO_ENABLE_COVERAGE "Enable coverage reporting" OFF)
 

--- a/include/igesio/common/parallel.h
+++ b/include/igesio/common/parallel.h
@@ -1,0 +1,96 @@
+/**
+ * @file common/parallel.h
+ * @brief 標準ライブラリのみで実装した並列実行ユーティリティ
+ * @author Yayoi Habami
+ * @date 2026-06-02
+ * @copyright 2026 Yayoi Habami
+ * @note <execution> (Parallel STL) やOpenMPに依存せず、std::async/std::futureのみで
+ *       実装する。これによりWindows/macOS/Linux × GCC/Clang + Windows×MSVCの全構成で、
+ *       追加の外部ライブラリなしに動作する (LinuxではThreads::Threadsのリンクのみ必要)。
+ */
+#ifndef IGESIO_COMMON_PARALLEL_H_
+#define IGESIO_COMMON_PARALLEL_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <future>
+#include <thread>
+#include <vector>
+
+
+
+namespace igesio {
+
+/// @brief 並列実行に切り替える最小要素数の既定値
+/// @note これ以下の要素数では直列実行する (スレッド生成のオーバーヘッドを避けるため)
+constexpr std::size_t kDefaultMinParallelSize = 2;
+
+/// @brief [0, count) の各インデックスに対しfuncを並列に適用する
+/// @tparam Func std::size_tを引数に取る呼び出し可能型
+/// @param count 反復回数
+/// @param func 各インデックスに適用する処理。func(i)の形で呼ばれる
+/// @param min_parallel_size 並列化する最小要素数 (これ以下は直列実行)
+/// @throws funcが送出した例外 (複数スレッドで生じた場合はいずれか一つを送出する)
+/// @note funcは異なるインデックスにつき高々一度ずつ、別スレッドから呼ばれうる。
+///       同一インデックスへの同時呼び出しは行わないため、各反復が互いに独立した
+///       書き込み先のみを扱う限りロックは不要。本関数は全ワーカーを待ち合わせてから返る
+///       (戻り時点でワーカーの書き込みは呼び出しスレッドから可視となる)。
+template <typename Func>
+void ParallelFor(const std::size_t count, const Func& func,
+                 const std::size_t min_parallel_size = kDefaultMinParallelSize) {
+    // ハードウェア並列度 (取得不能時は1とみなす)
+    unsigned int hw = std::thread::hardware_concurrency();
+    if (hw == 0) hw = 1;
+
+    // 直列フォールバック: 要素数が少ない、または並列度が1
+    if (count <= min_parallel_size || hw <= 1) {
+        for (std::size_t i = 0; i < count; ++i) func(i);
+        return;
+    }
+
+    // スレッド数を決定し、[0, count) を連続するチャンクへ分割する
+    const std::size_t n_threads = std::min(static_cast<std::size_t>(hw), count);
+    const std::size_t chunk = (count + n_threads - 1) / n_threads;
+
+    // 1チャンク [begin, end) を処理する
+    const auto run_chunk = [&func](std::size_t begin, std::size_t end) {
+        for (std::size_t i = begin; i < end; ++i) func(i);
+    };
+
+    // 先頭のn_threads-1チャンクを非同期起動し、末尾チャンクは呼び出しスレッドで実行する
+    std::vector<std::future<void>> futures;
+    futures.reserve(n_threads - 1);
+    for (std::size_t t = 0; t + 1 < n_threads; ++t) {
+        const std::size_t begin = t * chunk;
+        const std::size_t end = std::min(begin + chunk, count);
+        if (begin >= end) break;
+        futures.push_back(std::async(std::launch::async, run_chunk, begin, end));
+    }
+    const std::size_t last_begin = (n_threads - 1) * chunk;
+    if (last_begin < count) run_chunk(last_begin, count);
+
+    // 全ワーカーを待ち合わせる (例外は最初の一つを再送出する)
+    for (auto& f : futures) f.get();
+}
+
+/// @brief vectorの各要素に対しfuncを並列に適用する
+/// @tparam T 要素の型
+/// @tparam Func const T&を引数に取る呼び出し可能型
+/// @param items 対象の要素列
+/// @param func 各要素に適用する処理。func(items[i])の形で呼ばれる
+/// @param min_parallel_size 並列化する最小要素数 (これ以下は直列実行)
+/// @throws funcが送出した例外
+/// @note ParallelForのvector版。要素の読み取りは並列に行われるため、funcは各要素
+///       (および各要素が指す先) を書き換えない、または互いに独立した書き込みのみを行うこと。
+template <typename T, typename Func>
+void ParallelForEach(const std::vector<T>& items, const Func& func,
+                     const std::size_t min_parallel_size
+                             = kDefaultMinParallelSize) {
+    ParallelFor(items.size(),
+                [&items, &func](std::size_t i) { func(items[i]); },
+                min_parallel_size);
+}
+
+}  // namespace igesio
+
+#endif  // IGESIO_COMMON_PARALLEL_H_

--- a/include/igesio/entities/entity_base.h
+++ b/include/igesio/entities/entity_base.h
@@ -445,6 +445,12 @@ class EntityBase : public virtual IEntityIdentifier {
         return nullptr;
     }
 
+    /// @brief 幾何計算用の遅延キャッシュを事前構築する
+    /// @note 既定では何もしない。遅延キャッシュを持つエンティティ (TrimmedSurface等) が
+    ///       オーバーライドして事前計算を行う。並列実行から1エンティティにつき1回だけ
+    ///       呼ばれる前提とする (同一エンティティへの同時呼び出しは想定しない)。
+    virtual void PrepareGeometryCache() const {}
+
     /// @brief エンティティが参照する全てのエンティティのIDを取得する
     /// @return 参照する全てのエンティティのID
     /// @note Directory Entry フィールド関連のメンバも含む

--- a/include/igesio/entities/pd.h
+++ b/include/igesio/entities/pd.h
@@ -111,6 +111,22 @@ struct RawEntityPD {
 RawEntityPD
 ToRawEntityPD(const std::vector<std::string>&, const char, const char);
 
+/// @brief RawEntityPDを取得する (DEポインタ・シーケンス番号を呼び出し側が指定する版)
+/// @param lines 1レコード分の文字列を格納したベクタ
+/// @param p_delim パラメータ区切り文字
+/// @param r_delim レコード区切り文字
+/// @param de_pointer DEポインタ (lines[0]から抽出済みの既知値)
+/// @param sequence_number シーケンス番号 (lines[0]の末尾7桁の既知値)
+/// @return RawEntityPD構造体
+/// @throw igesio::LineFormatError 1行の長さが規定値以外の場合
+/// @throw igesio::SectionFormatError 与えられた文字列が自由形式として不正な場合
+/// @throw igesio::TypeConversionError エンティティタイプの変換に失敗した場合
+/// @note 読み込みのホットパス用. lines[0]からのDEポインタ/シーケンス番号の
+///       再抽出 (GetDEPointer/GetSequenceNumber) を省くためのオーバーロード.
+RawEntityPD
+ToRawEntityPD(const std::vector<std::string>&, const char, const char,
+              const unsigned int, const unsigned int);
+
 /// @brief パラメータデータセクションにおける、エンティティのパラメータの数を取得する
 /// @param type エンティティタイプ
 /// @param data エンティティタイプを除いた、パラメータ区切り文字で分割したパラメータ

--- a/include/igesio/entities/surfaces/trimmed_surface.h
+++ b/include/igesio/entities/surfaces/trimmed_surface.h
@@ -131,6 +131,10 @@ class TrimmedSurface : public EntityBase, public virtual ISurface {
     /// @note キャッシュが未構築の場合はBuildDomainCache()を呼び出す
     bool IsInDomain(const double u, const double v) const override;
 
+    /// @brief 領域判定キャッシュを事前構築する (BuildDomainCacheに委譲)
+    /// @note Assembly::PrepareGeometryCachesから並列に呼ばれることを想定する
+    void PrepareGeometryCache() const override;
+
 
 
     /**
@@ -199,7 +203,8 @@ class TrimmedSurface : public EntityBase, public virtual ISurface {
 
  private:
     /// @brief 包含多角形キャッシュを構築する
-    /// @note domain_cache_が有効な場合は何もしない
+    /// @note domain_cache_が有効な場合は何もしない。同一インスタンスに対して同時に
+    ///       呼び出してはならない (内部のdomain_cache_を非同期に書き込むため)。
     void BuildDomainCache() const;
 };
 

--- a/include/igesio/models/assembly.h
+++ b/include/igesio/models/assembly.h
@@ -517,6 +517,15 @@ class Assembly : public std::enable_shared_from_this<Assembly> {
     /// @note ワールド空間(このノードを含むルートまでの全大域変換を適用)で計算する.
     ///       幾何かつ物理従属でないメンバのみを対象とし、退化BBは既存ガードに倣って除外する.
     std::optional<numerics::BoundingBox> GetWorldBoundingBox() const;
+
+    /// @brief 子孫エンティティの遅延幾何キャッシュを並列に事前構築する
+    /// @param recursive trueの場合は全子孫を含める (デフォルト: true)
+    /// @note 各エンティティのEntityBase::PrepareGeometryCache()を1回ずつ呼ぶ
+    ///       (TrimmedSurfaceの領域判定キャッシュ等). 重い遅延計算を描画/クエリ前に
+    ///       まとめて済ませるための一括処理. 読み込み・構造編集 (キャッシュを無効化する
+    ///       Set/Add/Remove系) が完了し、並列読み取りを始める前に1回呼ぶこと.
+    ///       本メソッドは内部で全ワーカーを待ち合わせてから返る.
+    void PrepareGeometryCaches(bool recursive = true) const;
 };
 
 }  // namespace igesio::models

--- a/include/igesio/models/assembly.h
+++ b/include/igesio/models/assembly.h
@@ -237,6 +237,16 @@ class Assembly : public std::enable_shared_from_this<Assembly> {
         return id;
     }
 
+    /// @brief 複数のエンティティを一括で追加する
+    /// @param entities 追加するエンティティの配列
+    /// @throw std::invalid_argument いずれかのエンティティがnullptrの場合
+    /// @note 全エンティティをマップとルート逆引きインデックスへ登録した後、
+    ///       参照解決を1回だけ行う. 1件ずつ`AddEntity`を呼ぶ場合に生じる挿入
+    ///       ごとの全件走査 (O(N^2)) を回避し、O(エンティティ数+参照数)で完了する.
+    ///       多数のエンティティをまとめて読み込む場合に使用する.
+    void AddEntities(
+            const std::vector<std::shared_ptr<entities::EntityBase>>&);
+
     /// @brief エンティティが参照する全てのエンティティのポインタが設定済みか
     /// @return 一つでも未設定のポインタがある場合は`false`
     /// @note Directory Entry フィールド関連のメンバも含む. このノードのみを対象とする.

--- a/include/igesio/reader.h
+++ b/include/igesio/reader.h
@@ -192,16 +192,21 @@ ReadIgesIntermediate(const std::string&, const bool = false);
 
 /// @brief 中間データ構造からIgesDataクラスを生成する
 /// @param intermediate 中間データ構造
+/// @param prepare_caches エンティティのキャッシュを事前構築するかどうか
+///        (TrimmedSurfaceの領域判定キャッシュなど). デフォルトはtrue.
 /// @return 生成されたIgesDataクラス
 /// @throw igesio::DataFormatError パラメータの数や形式が不正な場合や、
 ///        参照されているエンティティが存在しない場合など
 models::IgesData
-ConvertFromIntermediate(const models::IntermediateIgesData&);
+ConvertFromIntermediate(const models::IntermediateIgesData&,
+                        const bool prepare_caches = true);
 
 /// @brief IGESファイルを読み込み、IgesDataクラスを返す
 /// @param file_path 読み込むIGESファイルのパス
 /// @param validate_strictly 仕様にのっとった厳密な検証を行うかどうか.
 ///        現状はDEセクションのデータ形式の検証のみを行う.
+/// @param prepare_caches エンティティのキャッシュを事前構築するかどうか
+///        (TrimmedSurfaceの領域判定キャッシュなど). デフォルトはtrue.
 /// @return 生成されたIgesDataクラス
 /// @throw igesio::FileOpenError ファイルが開けなかった場合
 /// @throw igesio::LineFormatError 行の長さが規定値以外の場合
@@ -210,7 +215,8 @@ ConvertFromIntermediate(const models::IntermediateIgesData&);
 ///        エンティティのPDパラメータが不正な場合や、参照が未解決の場合に発生する.
 /// @note 仕様に厳密には従っていないIGESファイルも存在するため、
 ///       validate_strictlyをtrueにする際は注意が必要.
-models::IgesData ReadIges(const std::string&, const bool = false);
+models::IgesData ReadIges(const std::string&,
+                          const bool = false, const bool = true);
 
 }  // namespace igesio
 

--- a/include/igesio/utils/iges_string_utils.h
+++ b/include/igesio/utils/iges_string_utils.h
@@ -97,6 +97,9 @@ std::string GetDataPart(const std::string&, const SectionType);
 ///        各行の長さは問わない.
 /// @param p_delim パラメータ区切り文字
 /// @param r_delim レコード区切り文字
+/// @param data_part_width 各行で連結対象とする先頭文字数 (データ部の列幅).
+///        既定 (npos) では行全体を連結する. 生の行＋列幅を渡すことで、各行を
+///        GetDataPartで切り詰めてから渡す際の中間コピーを避けられる.
 /// @return データ部をパラメータ区切り文字で分割した文字列のベクタ
 /// @throw igesio::SectionFormatError 区切り文字が存在しない場合、
 ///        不正な文字列ステートメント（H文字列）が含まれる場合、
@@ -111,7 +114,8 @@ std::string GetDataPart(const std::string&, const SectionType);
 /// @note PDセクションのコメント (レコード区切り文字の後に追加されうる文字列) は
 ///       無視される (単純に切り捨てられ、返されない).
 std::vector<std::string>
-ParseFreeFormattedData(const std::vector<std::string>&, const char, const char);
+ParseFreeFormattedData(const std::vector<std::string>&, const char, const char,
+                       const std::size_t = std::string::npos);
 
 
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,10 @@ target_include_directories(igesio_common PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# Link Threads (std::async/std::thread backend for common/parallel.h).
+# PUBLIC so every library that depends on IGESio::common transitively links it.
+target_link_libraries(igesio_common PUBLIC Threads::Threads)
+
 # Handle Eigen dependency if enabled
 if(IGESIO_ENABLE_EIGEN)
     target_link_libraries(igesio_common PUBLIC

--- a/src/common/serialization.cpp
+++ b/src/common/serialization.cpp
@@ -230,11 +230,12 @@ std::pair<double, igesio::ValueFormat> igesio::FromIgesRealWithFormat(
 
     // 前後から空白を削除して実数に変換
     auto trimmed = igesio::trim(str);
-    if (!IsDigitOrSign(trimmed[0])) {
-        // 先頭が数字でない場合 (\t等の::stripで削除されない空白文字がある場合)
+    if (!IsDigitOrSign(trimmed[0]) && trimmed[0] != '.') {
+        // 先頭が数字・符号・小数点のいずれでもない場合
+        // (整数部のない実数 ".5" を許容し、"-.5" を受理することとの非対称を避ける)
         throw igesio::TypeConversionError(
                 "Invalid double value: '" + str + "'"
-                " The string must begin with a digit or sign character");
+                " The string must begin with a digit, sign, or decimal point");
     }
 
     try {

--- a/src/common/serialization.cpp
+++ b/src/common/serialization.cpp
@@ -7,10 +7,14 @@
  */
 #include "igesio/common/serialization.h"
 
+#include <cerrno>
+#include <charconv>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <utility>
 
 #include "igesio/common/errors.h"
@@ -67,39 +71,47 @@ std::string ConvertDToE(const std::string& str) {
     return result;
 }
 
-/// @brief 数値が単精度か否か
-/// @param str Real型の文字列
-/// @return 文字列内に 'E' が含まれている場合は単精度と判断
-bool IsSinglePrecision(const std::string& str) {
-    return str.find('E') != std::string::npos;
-}
+/// @brief Real型文字列のフォーマット情報
+struct RealFormatInfo {
+    /// @brief 整数部があるか
+    bool has_integer = false;
+    /// @brief 小数部があるか
+    bool has_fraction = false;
+    /// @brief 指数部 (E/D) があるか
+    bool has_exponent = false;
+    /// @brief 単精度 (E指数) か
+    bool is_single_precision = false;
+    /// @brief D指数表記を含むか (D->E変換が必要)
+    bool has_d = false;
+};
 
-/// @brief 数値に整数部があるか否か
-/// @param str Real型の文字列
-/// @return 文字列の先頭 (または先頭が符号の場合はその次の文字)
-///         が数字である場合は整数部があると判断
-bool HasIntegerPart(const std::string& str) {
-    if (str.empty()) return false;
-    size_t start = (str[0] == '+' || str[0] == '-') ? 1 : 0;
-    return start < str.size() && IsDigit(str[start]);
-}
-
-/// @brief 数値に小数部があるか否か
-/// @param str Real型の文字列
-/// @return 文字列内の '.' の次の文字が数字である場合は小数部があると判断
-bool HasFractionPart(const std::string& str) {
-    size_t dot_pos = str.find('.');
-    if (dot_pos == std::string::npos) return false;
-    // '.' の次の文字が数字であるかを確認
-    return dot_pos + 1 < str.size() && IsDigit(str[dot_pos + 1]);
-}
-
-/// @brief 数値に指数部があるか否か
-/// @param str Real型の文字列 (指数部は 'E' または 'D' で始まる)
-/// @return 文字列内に 'E' または 'D' が含まれている場合は指数部があると判断
-bool HasExponentPart(const std::string& str) {
-    return str.find('E') != std::string::npos ||
-           str.find('D') != std::string::npos;
+/// @brief Real型文字列の範囲 [begin, end) からフォーマット情報を算出する
+/// @param str 対象文字列
+/// @param begin 内容の開始位置 (前方の空白を除いた位置)
+/// @param end 内容の終端位置 (後方の空白を除いた次の位置; exclusive)
+/// @return フォーマット情報
+/// @note 文字列を確保せず、範囲を1パス走査して算出する
+RealFormatInfo AnalyzeRealFormat(const std::string& str,
+                                 const std::size_t begin, const std::size_t end) {
+    RealFormatInfo info;
+    // 整数部: 先頭 (符号があればその次) が数字か
+    const std::size_t int_pos =
+            (str[begin] == '+' || str[begin] == '-') ? begin + 1 : begin;
+    info.has_integer = (int_pos < end) && IsDigit(str[int_pos]);
+    // 小数部・指数部を1パスで走査して判定する
+    for (std::size_t i = begin; i < end; ++i) {
+        const char c = str[i];
+        if (c == '.') {
+            if (i + 1 < end && IsDigit(str[i + 1])) info.has_fraction = true;
+        } else if (c == 'E') {
+            info.has_exponent = true;
+            info.is_single_precision = true;
+        } else if (c == 'D') {
+            info.has_exponent = true;
+            info.has_d = true;
+        }
+    }
+    return info;
 }
 
 }  // namespace
@@ -188,34 +200,37 @@ std::pair<int, igesio::ValueFormat> igesio::FromIgesIntegerWithFormat(
         return {default_value.value(), ValueFormat::Integer(true)};
     }
 
-    // 前後から空白を削除して整数に変換
-    auto trimmed = igesio::trim(str);
-    if (!IsDigitOrSign(trimmed[0])) {
-        // 先頭が数字でない場合 (\t等の::stripで削除されない空白文字がある場合)
+    // 前後の空白は確保せずに範囲で扱う (空白のみはAssert...で除外済)
+    const std::size_t first = str.find_first_not_of(' ');
+    const std::size_t last = str.find_last_not_of(' ');  // inclusive
+    const char head = str[first];
+    if (!IsDigitOrSign(head)) {
+        // 先頭が数字でも符号でもない場合 (タブ等の::stripで残る空白文字を含む)
         throw igesio::TypeConversionError(
                 "Invalid integer value: '" + str + "'"
                 " The string must begin with a digit or sign character");
     }
+    // 符号がある場合、その直後は数字でなければならない ("+-42"等を弾く)
+    if ((head == '+' || head == '-') &&
+            (first + 1 > last || !IsDigit(str[first + 1]))) {
+        throw igesio::TypeConversionError("Invalid integer value: '" + str + "'");
+    }
 
-    try {
-        std::size_t pos = 0;
-        int value = std::stoi(trimmed, &pos);
-
-        // 変換して残った文字列が空でない場合はエラー
-        if (pos != trimmed.length()) {
-            throw igesio::TypeConversionError(
-                    "Invalid integer value: '" + str + "'");
-        }
-        return {value, ValueFormat::Integer(false, trimmed[0] == '+')};
-    } catch (const std::invalid_argument&) {
-        // 変換できなかった場合はエラー
-        throw igesio::TypeConversionError(
-                "Invalid integer value: '" + str + "'");
-    } catch (const std::out_of_range&) {
+    // from_charsは先頭'+'を受け付けないため'+'のみスキップする ('-'はfrom_charsが扱う)
+    const char* begin = str.data() + (head == '+' ? first + 1 : first);
+    const char* end = str.data() + last + 1;
+    int value = 0;
+    const auto result = std::from_chars(begin, end, value);
+    if (result.ec == std::errc::result_out_of_range) {
         // 範囲外の場合はエラー
         throw igesio::TypeConversionError(
                 "Integer value out of range: '" + str + "'");
+    } else if (result.ec != std::errc() || result.ptr != end) {
+        // 変換失敗、または数値の後ろに余分な文字が残る場合
+        throw igesio::TypeConversionError(
+                "Invalid integer value: '" + str + "'");
     }
+    return {value, ValueFormat::Integer(false, head == '+')};
 }
 
 std::pair<double, igesio::ValueFormat> igesio::FromIgesRealWithFormat(
@@ -228,56 +243,68 @@ std::pair<double, igesio::ValueFormat> igesio::FromIgesRealWithFormat(
         return {default_value.value(), ValueFormat::Real(true)};
     }
 
-    // 前後から空白を削除して実数に変換
-    auto trimmed = igesio::trim(str);
-    if (!IsDigitOrSign(trimmed[0]) && trimmed[0] != '.') {
+    // 前後の空白は確保せずに範囲で扱う (空白のみはAssert...で除外済)
+    const std::size_t first = str.find_first_not_of(' ');
+    const std::size_t last = str.find_last_not_of(' ');  // inclusive
+    const std::size_t end_pos = last + 1;                // exclusive
+    const char head = str[first];
+    if (!IsDigitOrSign(head) && head != '.') {
         // 先頭が数字・符号・小数点のいずれでもない場合
         // (整数部のない実数 ".5" を許容し、"-.5" を受理することとの非対称を避ける)
         throw igesio::TypeConversionError(
                 "Invalid double value: '" + str + "'"
                 " The string must begin with a digit, sign, or decimal point");
     }
+    // 符号がある場合、その直後は数字または小数点でなければならない ("+-4.2"等を弾く)
+    if ((head == '+' || head == '-') &&
+            (first + 1 >= end_pos ||
+             !(IsDigit(str[first + 1]) || str[first + 1] == '.'))) {
+        throw igesio::TypeConversionError("Invalid real value: '" + str + "'");
+    }
 
-    try {
-        // 単精度か否かを判断し、互換性のためにDをEに変換
-        auto is_single_precision = IsSinglePrecision(trimmed);
-        std::size_t pos = 0;
-        double value = std::stod(ConvertDToE(trimmed), &pos);
+    // フォーマット情報を範囲から算出する (確保なし)
+    const RealFormatInfo info = AnalyzeRealFormat(str, first, end_pos);
+    const bool has_plus_sign = (head == '+');
 
-        // その他のフォーマット情報を取得
-        bool has_plus_sign = trimmed[0] == '+';
-        bool has_integer = HasIntegerPart(trimmed);
-        bool has_fraction = HasFractionPart(trimmed);
-        bool has_exponent = HasExponentPart(trimmed);
-
-        // 変換して残った文字列が空でない場合はエラー
-        if (pos != trimmed.length()) {
+    // 数値へ変換する.
+    // NOTE: MinGWのlibstdc++はfrom_chars<double>を提供しないため、整数と異なり
+    //       実数はstrtodで変換する (stodと同じ変換だが、c_str()上を直接パースして
+    //       trim/部分文字列の確保を避ける). 'D'指数のみ事前にD->E変換する.
+    double value = 0.0;
+    char* endptr = nullptr;
+    errno = 0;
+    if (info.has_d) {
+        // D指数表記を含む稀なケースはD->E変換してから変換する (確保あり)
+        const std::string conv = ConvertDToE(str.substr(first, last - first + 1));
+        value = std::strtod(conv.c_str(), &endptr);
+        if (endptr != conv.c_str() + conv.size()) {
             throw igesio::TypeConversionError(
                     "Invalid real value: '" + str + "'");
         }
-
-        // アンダーフローの明示的なチェック
-        // Windows&Clangでは、std::stodが2.225...e-309のような値を与えられても
-        // 0.0を返すことがあるため、明示的にチェックする
-        if (std::isfinite(value) && value != 0.0) {
-            if (std::abs(value) < std::numeric_limits<double>::min()) {
-                throw igesio::TypeConversionError(
-                        "Real value underflow: '" + str + "'");
-            }
+    } else {
+        value = std::strtod(str.c_str() + first, &endptr);
+        if (endptr != str.data() + end_pos) {
+            // 変換失敗、または数値の後ろに余分な文字が残る場合
+            throw igesio::TypeConversionError(
+                    "Invalid real value: '" + str + "'");
         }
-
-        return {value, ValueFormat::Real(
-                false, has_plus_sign, has_integer, has_fraction,
-                has_exponent, is_single_precision)};
-    } catch (const std::invalid_argument&) {
-        // 変換できなかった場合はエラー
-        throw igesio::TypeConversionError(
-                "Invalid real value: '" + str + "'");
-    } catch (const std::out_of_range&) {
-        // 範囲外の場合はエラー
-        throw igesio::TypeConversionError(
-                "Real value out of range: '" + str + "'");
     }
+    if (errno == ERANGE) {
+        // オーバーフロー(±HUGE_VAL)・アンダーフロー(0/非正規化数)
+        throw igesio::TypeConversionError("Real value out of range: '" + str + "'");
+    }
+
+    // アンダーフローの明示的なチェック
+    // Windows&Clangでは、std::stodが2.225...e-309のような値を与えられても
+    // 0.0を返すことがあるため、明示的にチェックする
+    if (std::isfinite(value) && value != 0.0 &&
+            std::abs(value) < std::numeric_limits<double>::min()) {
+        throw igesio::TypeConversionError("Real value underflow: '" + str + "'");
+    }
+
+    return {value, ValueFormat::Real(false, has_plus_sign, info.has_integer,
+                                     info.has_fraction, info.has_exponent,
+                                     info.is_single_precision)};
 }
 
 std::pair<std::string, igesio::ValueFormat> igesio::FromIgesStringWithFormat(

--- a/src/entities/curves/algorithms.cpp
+++ b/src/entities/curves/algorithms.cpp
@@ -71,9 +71,9 @@ i_ent::ComputeContainmentPolygons(
         const Vector3d& reference_normal,
         double curvature_eps,
         double distance_eps) {
-    auto circumscribed = ComputeCircumscribedPolygon(
-        curve, n_vert, reference_normal, curvature_eps);
-    auto inscribed = ComputeInscribedPolygon(
+    // 外包・内包は前段 (均等サンプリング・曲線プロパティ計算等) を共有して
+    // 一度に計算する (個別呼び出しと結果は一致)
+    auto [circumscribed, inscribed] = ComputeExtremalPolygonPair(
         curve, n_vert, reference_normal, curvature_eps);
     auto approximate = ComputeApproximatePolygon(
         curve, inscribed, circumscribed, distance_eps);

--- a/src/entities/curves/algorithms/extremal_polygon.cpp
+++ b/src/entities/curves/algorithms/extremal_polygon.cpp
@@ -1006,6 +1006,130 @@ std::vector<double> FindContainmentViolations(
 // 主関数
 // ===========================================================================
 
+/// @brief 外包/内包多角形で共有できる前段の計算結果
+/// @note circumscribed に依存しない値をまとめ、外包・内包で再計算を避ける.
+struct ExtremalPolygonSharedData {
+    /// @brief パラメータ範囲の下限
+    double t0 = 0.0;
+    /// @brief パラメータ範囲の上限
+    double t1 = 0.0;
+    /// @brief パラメータ範囲の幅 (t1 - t0)
+    double period = 0.0;
+    /// @brief 均等分割されたパラメータ値列
+    std::vector<double> t_uniform;
+    /// @brief 向き符号 (符号付き面積の符号)
+    double orient_sign = 1.0;
+    /// @brief 含有検証用の平面基底 (u 軸)
+    Vector3d plane_u = Vector3d::Zero();
+    /// @brief 含有検証用の平面基底 (v 軸)
+    Vector3d plane_v = Vector3d::Zero();
+    /// @brief 曲線領域 (均等点の2次元射影)
+    std::vector<std::array<double, 2>> region2d;
+    /// @brief 多角形構築のための初期サンプル点 (パラメータ値列)
+    std::vector<double> ts_initial;
+};
+
+/// @brief 外包/内包多角形で共有する前段 (circumscribed 非依存) を計算する
+///
+/// @param curve 対象の閉曲線 (自己交差なし)
+/// @param n_vert 初期分割数
+/// @param normal 平面の参照法線ベクトル
+/// @return 共有前段データ
+/// @throws std::invalid_argument n_vert が 3 未満の場合
+ExtremalPolygonSharedData PrepareExtremalPolygonData(
+        const i_ent::ICurve& curve,
+        int n_vert,
+        const Vector3d& normal) {
+    if (n_vert < 3) {
+        throw std::invalid_argument(
+            "n_vert は 3 以上でなければなりません。n_vert: "
+            + std::to_string(n_vert));
+    }
+
+    // 均等サンプリング (CheckCurveProperties と FindCurvatureExtrema で共用)
+    constexpr int kNInit = 500;
+    ExtremalPolygonSharedData s;
+    const auto [t0, t1] = curve.GetParameterRange();
+    s.t0 = t0;
+    s.t1 = t1;
+    s.period = t1 - t0;
+
+    s.t_uniform.resize(kNInit);
+    std::vector<Vector3d> pts_uniform(kNInit);
+    for (int i = 0; i < kNInit; ++i) {
+        s.t_uniform[i] = t0 + s.period * i / kNInit;
+        pts_uniform[i] = curve.GetPointAt(s.t_uniform[i]);
+    }
+
+    // 閉曲線チェック・向き符号計算・自己交差チェック
+    s.orient_sign = CheckCurveProperties(curve, pts_uniform, normal);
+
+    // 含有検証用の平面基底と曲線領域(均等点の射影)を用意する
+    const auto [u, v] = BuildPlaneBasis(normal);
+    s.plane_u = u;
+    s.plane_v = v;
+    s.region2d.resize(kNInit);
+    for (int i = 0; i < kNInit; ++i) {
+        s.region2d[i] = ProjectTo2D(pts_uniform[i], u, v);
+    }
+
+    // 多角形構築のためのサンプル点を生成する
+    s.ts_initial = SamplePoints(curve, normal, s.t_uniform, n_vert).first;
+
+    return s;
+}
+
+/// @brief 共有前段をもとに外包/内包多角形を細分しながら構築する
+///
+/// @param curve 対象の閉曲線
+/// @param circumscribed 外包なら true, 内包なら false
+/// @param normal 平面の参照法線ベクトル
+/// @param eps 曲率判定の閾値
+/// @param s 共有前段 (PrepareExtremalPolygonData の結果)
+/// @return 多角形データ
+i_num::PolygonData RefineExtremalPolygon(
+        const i_ent::ICurve& curve,
+        bool circumscribed,
+        const Vector3d& normal,
+        double eps,
+        const ExtremalPolygonSharedData& s) {
+    // 含有不変条件を満たすまで、違反点をサンプルに追加して再構築する。
+    // (案A: 分類/構成が不変条件を満たすことを仮定せず、構築後に強制する。
+    //  これにより変曲点・接合コーナー・粗標本化に起因する内包性違反を解消する。)
+    constexpr int kMaxRefine = 6;
+    constexpr double kViolationEps = 1e-7;
+    // 細分は外包・内包で独立に行うため、初期サンプルをコピーして用いる
+    std::vector<double> ts = s.ts_initial;
+    i_num::PolygonData polygon;
+    for (int iter = 0; ; ++iter) {
+        std::vector<Vector3d> pts;
+        pts.reserve(ts.size());
+        // tは曲率極値・違反点由来で [t0, t1] を僅かに外れ得るためクランプする
+        for (double t : ts) {
+            pts.push_back(curve.GetPointAt(std::clamp(t, s.t0, s.t1)));
+        }
+
+        // 各点を頂点/接点に分類し、多角形を構築・重複除去する
+        const auto is_contact = ClassifyPoints(
+            curve, ts, circumscribed, normal, s.orient_sign, eps);
+        polygon = DedupPolygon(
+            BuildPolygonVertices(curve, ts, pts, is_contact, normal));
+
+        if (iter >= kMaxRefine) break;
+
+        // 含有違反を検出し、違反があれば違反点をサンプルへ追加して再試行する
+        const auto extra = FindContainmentViolations(
+            polygon, circumscribed, s.plane_u, s.plane_v, s.t_uniform,
+            s.region2d, s.period, s.t1, kViolationEps);
+        if (extra.empty()) break;
+
+        ts.insert(ts.end(), extra.begin(), extra.end());
+        ts = Dedup(ts, curve.IsClosed(), s.period, 1e-6);
+    }
+
+    return polygon;
+}
+
 /// @brief 外包/内包多角形の頂点列を計算する内部実装
 ///
 /// @param curve 対象の閉曲線 (自己交差なし)
@@ -1020,70 +1144,9 @@ i_num::PolygonData ComputeExtremalPolygon(
         bool circumscribed,
         const Vector3d& normal,
         double eps) {
-    if (n_vert < 3) {
-        throw std::invalid_argument(
-            "n_vert は 3 以上でなければなりません。n_vert: "
-            + std::to_string(n_vert));
-    }
-
-    // 均等サンプリング (CheckCurveProperties と FindCurvatureExtrema で共用)
-    constexpr int kNInit = 500;
-    const auto [t0, t1] = curve.GetParameterRange();
-    const double period = t1 - t0;
-
-    std::vector<double> t_uniform(kNInit);
-    std::vector<Vector3d> pts_uniform(kNInit);
-    for (int i = 0; i < kNInit; ++i) {
-        t_uniform[i] = t0 + period * i / kNInit;
-        pts_uniform[i] = curve.GetPointAt(t_uniform[i]);
-    }
-
-    // 閉曲線チェック・向き符号計算・自己交差チェック
-    const double orient_sign = CheckCurveProperties(
-        curve, pts_uniform, normal);
-
-    // 含有検証用の平面基底と曲線領域(均等点の射影)を用意する
-    const auto [u, v] = BuildPlaneBasis(normal);
-    std::vector<std::array<double, 2>> region2d(kNInit);
-    for (int i = 0; i < kNInit; ++i) {
-        region2d[i] = ProjectTo2D(pts_uniform[i], u, v);
-    }
-
-    // 多角形構築のためのサンプル点を生成する
-    std::vector<double> ts = SamplePoints(
-        curve, normal, t_uniform, n_vert).first;
-
-    // 含有不変条件を満たすまで、違反点をサンプルに追加して再構築する。
-    // (案A: 分類/構成が不変条件を満たすことを仮定せず、構築後に強制する。
-    //  これにより変曲点・接合コーナー・粗標本化に起因する内包性違反を解消する。)
-    constexpr int kMaxRefine = 6;
-    constexpr double kViolationEps = 1e-7;
-    i_num::PolygonData polygon;
-    for (int iter = 0; ; ++iter) {
-        std::vector<Vector3d> pts;
-        pts.reserve(ts.size());
-        // tは曲率極値・違反点由来で [t0, t1] を僅かに外れ得るためクランプする
-        for (double t : ts) pts.push_back(curve.GetPointAt(std::clamp(t, t0, t1)));
-
-        // 各点を頂点/接点に分類し、多角形を構築・重複除去する
-        const auto is_contact = ClassifyPoints(
-            curve, ts, circumscribed, normal, orient_sign, eps);
-        polygon = DedupPolygon(
-            BuildPolygonVertices(curve, ts, pts, is_contact, normal));
-
-        if (iter >= kMaxRefine) break;
-
-        // 含有違反を検出し、違反があれば違反点をサンプルへ追加して再試行する
-        const auto extra = FindContainmentViolations(
-            polygon, circumscribed, u, v, t_uniform, region2d,
-            period, t1, kViolationEps);
-        if (extra.empty()) break;
-
-        ts.insert(ts.end(), extra.begin(), extra.end());
-        ts = Dedup(ts, curve.IsClosed(), period, 1e-6);
-    }
-
-    return polygon;
+    const ExtremalPolygonSharedData s =
+        PrepareExtremalPolygonData(curve, n_vert, normal);
+    return RefineExtremalPolygon(curve, circumscribed, normal, eps, s);
 }
 
 }  // namespace
@@ -1108,6 +1171,22 @@ i_num::PolygonData ComputeInscribedPolygon(
         double eps) {
     return ComputeExtremalPolygon(
         curve, n_vert, /*circumscribed=*/false, reference_normal, eps);
+}
+
+std::pair<i_num::PolygonData, i_num::PolygonData>
+ComputeExtremalPolygonPair(
+        const ICurve& curve,
+        int n_vert,
+        const Vector3d& reference_normal,
+        double eps) {
+    // 外包/内包に依存しない前段を一度だけ計算して共有する
+    const ExtremalPolygonSharedData s =
+        PrepareExtremalPolygonData(curve, n_vert, reference_normal);
+    i_num::PolygonData circumscribed = RefineExtremalPolygon(
+        curve, /*circumscribed=*/true, reference_normal, eps, s);
+    i_num::PolygonData inscribed = RefineExtremalPolygon(
+        curve, /*circumscribed=*/false, reference_normal, eps, s);
+    return {std::move(circumscribed), std::move(inscribed)};
 }
 
 }  // namespace igesio::entities

--- a/src/entities/curves/algorithms/extremal_polygon.h
+++ b/src/entities/curves/algorithms/extremal_polygon.h
@@ -12,6 +12,8 @@
 #ifndef SRC_ENTITIES_CURVES_ALGORITHMS_EXTREMAL_POLYGON_H_
 #define SRC_ENTITIES_CURVES_ALGORITHMS_EXTREMAL_POLYGON_H_
 
+#include <utility>
+
 #include "igesio/numerics/matrix.h"
 #include "igesio/numerics/polygon.h"
 #include "igesio/entities/interfaces/i_curve.h"
@@ -51,6 +53,27 @@ numerics::PolygonData ComputeCircumscribedPolygon(
 /// @throws std::invalid_argument curve が閉曲線でない場合、自己交差が検出された場合
 /// @throws std::runtime_error 接線・曲率の計算に失敗した場合
 numerics::PolygonData ComputeInscribedPolygon(
+    const ICurve& curve,
+    int n_vert,
+    const Vector3d& reference_normal,
+    double eps = 1e-9);
+
+/// @brief 外包多角形と内包多角形を一度に計算する (前段の共有による高速化)
+///
+/// 外包/内包に依存しない前段 (均等サンプリング・曲線プロパティ計算・初期サンプル
+/// 点生成) を一度だけ実行し、外包・内包の両多角形を構築する.
+/// ComputeCircumscribedPolygon と ComputeInscribedPolygon を個別に呼んだ場合と
+/// 結果は一致するが、共有前段ぶん高速.
+///
+/// @param curve 対象の閉曲線 (自己交差なし). 角点を含んでもよい.
+/// @param n_vert 初期分割数 (実際の頂点数はこれより多くなる場合あり)
+/// @param reference_normal 曲線が乗る平面の法線ベクトル (正規化不要)
+/// @param eps 曲率判定の閾値
+/// @return {外包多角形, 内包多角形} の頂点データ
+/// @throws std::invalid_argument curve が閉曲線でない場合、自己交差が検出された場合
+/// @throws std::runtime_error 接線・曲率の計算に失敗した場合
+std::pair<numerics::PolygonData, numerics::PolygonData>
+ComputeExtremalPolygonPair(
     const ICurve& curve,
     int n_vert,
     const Vector3d& reference_normal,

--- a/src/entities/curves/algorithms/polygonal_approximation.cpp
+++ b/src/entities/curves/algorithms/polygonal_approximation.cpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 #include <array>
-#include <tuple>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -38,11 +38,36 @@ bool IsIntervalInLinearSegment(
     return false;
 }
 
+/// @brief パラメータ値と、その点における曲線上の評価済み座標
+/// @note pointが値を持つ場合、細分中に評価済みのためPolygonDataの構築時に再評価しない.
+///       区間先頭・直線部確定・範囲外端点ではnulloptとなり、
+///       PolygonDataの構築時に評価する.
+struct ParamPoint {
+    /// @brief 曲線パラメータ値
+    double param;
+    /// @brief paramにおける曲線上の点 (範囲内). 未評価の場合はnullopt
+    std::optional<Vector3d> point;
+};
+
+/// @brief 反復二分法のスタック要素 (区間と、引き継いだ端点評価値)
+struct Interval {
+    /// @brief 区間左端・右端のパラメータ値
+    double ua, ub;
+    /// @brief 端点ua, ubにおける評価済みの点. 親から引き継ぎ再評価を避ける.
+    ///        未評価の場合はnullopt
+    std::optional<Vector3d> pa, pb;
+    /// @brief スタック深度
+    int depth;
+};
+
 /// @brief スタックを用いた反復二分法で区間 [u_a, u_b] を折れ線近似する
 ///
 /// 「辺と弧の中点との点-直線距離 <= eps」を満たすまで区間を再帰的に二分する.
 /// 再帰の代わりに明示的なスタックを用い、左側の区間を優先して処理することで
 /// 出力パラメータ列がu_aからu_bへと昇順に並ぶことを保証する.
+///
+/// 子区間の端点は親が評価済みの点 (外側端点と中点) をそのまま引き継ぐため、
+/// 各区間で新規に評価するのは中点のみとなり、端点の再評価を避ける.
 ///
 /// @param curve 対象の曲線
 /// @param u_a 区間左端のパラメータ値
@@ -50,54 +75,55 @@ bool IsIntervalInLinearSegment(
 /// @param linear_segments GetLinearSegments()の結果
 /// @param eps 許容距離
 /// @param max_depth 最大スタック深度
-/// @return u_aからu_bまでのパラメータ列 (両端を含む)
-std::vector<double> SubdivideWithParams(
+/// @return u_aからu_bまでのパラメータ列 (両端を含む). 各要素は評価済みの点を
+///         保持しうる (未評価はnullopt)
+std::vector<ParamPoint> SubdivideWithParams(
         const i_ent::ICurve& curve,
         double u_a, double u_b,
         const std::vector<std::array<double, 2>>& linear_segments,
         double eps, int max_depth) {
-    std::vector<double> confirmed = {u_a};
-    // スタック: (u_left, u_right, depth)
-    // 右サブ区間を先に積む (LIFOなので左が先に処理される)
-    std::vector<std::tuple<double, double, int>> stack = {{u_a, u_b, 0}};
+    std::vector<ParamPoint> confirmed = {{u_a, std::nullopt}};
+    // スタック: 右サブ区間を先に積む (LIFOなので左が先に処理される)
+    std::vector<Interval> stack = {{u_a, u_b, std::nullopt, std::nullopt, 0}};
 
     while (!stack.empty()) {
-        auto [ua, ub, depth] = stack.back();
+        Interval iv = stack.back();
         stack.pop_back();
 
         // 終了条件1: 直線部に完全に含まれる
-        if (IsIntervalInLinearSegment(ua, ub, linear_segments)) {
-            confirmed.push_back(ub);
+        if (IsIntervalInLinearSegment(iv.ua, iv.ub, linear_segments)) {
+            confirmed.push_back({iv.ub, iv.pb});
             continue;
         }
+
+        // 端点・中点を評価する (端点は親から引き継いだ値があれば再利用)
+        const double u_mid = 0.5 * (iv.ua + iv.ub);
+        if (!iv.pa) iv.pa = curve.TryGetPointAt(iv.ua);
+        if (!iv.pb) iv.pb = curve.TryGetPointAt(iv.ub);
+        const auto pm = curve.TryGetPointAt(u_mid);
+        if (!iv.pa || !iv.pb || !pm) {
+            // 計算失敗時は分割を打ち切る
+            confirmed.push_back({iv.ub, iv.pb});
+            continue;
+        }
+        const double dist = i_ent::PointLineDistance(*pm, *iv.pa, *iv.pb);
 
         // 終了条件2: 中点距離が許容値以下
-        double u_mid = 0.5 * (ua + ub);
-        auto pa_opt = curve.TryGetPointAt(ua);
-        auto pb_opt = curve.TryGetPointAt(ub);
-        auto pm_opt = curve.TryGetPointAt(u_mid);
-        if (!pa_opt || !pb_opt || !pm_opt) {
-            // 計算失敗時は分割を打ち切る
-            confirmed.push_back(ub);
-            continue;
-        }
-        double dist = i_ent::PointLineDistance(*pm_opt, *pa_opt, *pb_opt);
-
         if (dist <= eps) {
-            confirmed.push_back(ub);
+            confirmed.push_back({iv.ub, iv.pb});
             continue;
         }
 
         // 終了条件3: 最大深度超過
-        if (depth >= max_depth) {
-            confirmed.push_back(u_mid);
-            confirmed.push_back(ub);
+        if (iv.depth >= max_depth) {
+            confirmed.push_back({u_mid, pm});
+            confirmed.push_back({iv.ub, iv.pb});
             continue;
         }
 
-        // 右サブ区間を先に積む
-        stack.push_back({u_mid, ub, depth + 1});
-        stack.push_back({ua, u_mid, depth + 1});
+        // 右サブ区間を先に積む (端点の評価値を子へ引き継ぐ)
+        stack.push_back({u_mid, iv.ub, pm, iv.pb, iv.depth + 1});
+        stack.push_back({iv.ua, u_mid, iv.pa, pm, iv.depth + 1});
     }
 
     return confirmed;
@@ -116,7 +142,7 @@ i_num::PolygonData i_ent::ComputeApproximatePolygon(
     auto [t_min, t_max] = curve.GetParameterRange();
     auto linear_segments = curve.GetLinearSegments();
 
-    // Step 1: 固定点パラメータの収集・ソート・重複除去
+    // 固定点パラメータの収集・ソート・重複除去
     // inscribed/circumscribedのon_curve=trueの頂点とt_min/t_maxを固定点とする
     std::vector<double> fixed_params;
     for (const auto* pd : {&inscribed, &circumscribed}) {
@@ -135,37 +161,46 @@ i_num::PolygonData i_ent::ComputeApproximatePolygon(
         std::unique(fixed_params.begin(), fixed_params.end()),
         fixed_params.end());
 
-    // Step 2: 各固定点間の区間を折れ線近似
-    std::vector<double> result_params;
+    // 各固定点間の区間を折れ線近似
+    std::vector<ParamPoint> result;
     for (size_t idx = 0; idx + 1 < fixed_params.size(); ++idx) {
         auto interval = SubdivideWithParams(
             curve, fixed_params[idx], fixed_params[idx + 1],
             linear_segments, eps, max_depth);
 
         if (idx == 0) {
-            result_params.insert(result_params.end(),
-                interval.begin(), interval.end());
+            result.insert(result.end(), interval.begin(), interval.end());
         } else {
             // u_aは前区間の末尾と重複するため除く
-            result_params.insert(result_params.end(),
-                interval.begin() + 1, interval.end());
+            result.insert(result.end(), interval.begin() + 1, interval.end());
         }
     }
 
     // 閉曲線の場合、末尾のt_max (= t_min と同一点) を除去する
-    if (curve.IsClosed() && result_params.size() > 1 &&
-            i_num::IsApproxEqual(result_params.back(), t_max)) {
-        result_params.pop_back();
+    if (curve.IsClosed() && result.size() > 1 &&
+            i_num::IsApproxEqual(result.back().param, t_max)) {
+        result.pop_back();
     }
 
-    // Step 3: PolygonDataの構築
-    // uは固定点 (inscribed/circumscribedの曲率パラメータ等) 由来で、閉曲線の周期
-    // 正規化などにより [t_min, t_max] を僅かに外れることがある。GetPointAt の範囲外
-    // 例外を避けるため評価時に範囲へクランプする (C層: 数値誤差でも例外を投げない)。
+    // PolygonDataの構築
+    // 細分中に評価済みの点はそのまま再利用し、
+    // 未評価の点 (区間先頭・直線部確定・範囲外端点) のみGetPointAtで評価する
+    // 固定点 (inscribed/circumscribedの曲率パラメータ等) は
+    // 閉曲線の周期正規化などにより [t_min, t_max] を僅かに外れる
+    // ことがあるため、評価時は範囲へクランプしてGetPointAtの範囲外例外を避ける
+    // (C層: 数値誤差でも例外を投げない)。
     std::vector<Vector3d> vertices;
-    vertices.reserve(result_params.size());
-    for (double u : result_params) {
-        vertices.push_back(curve.GetPointAt(std::clamp(u, t_min, t_max)));
+    std::vector<double> result_params;
+    vertices.reserve(result.size());
+    result_params.reserve(result.size());
+    for (const auto& pp : result) {
+        result_params.push_back(pp.param);
+        if (pp.point) {
+            vertices.push_back(*pp.point);
+        } else {
+            vertices.push_back(
+                curve.GetPointAt(std::clamp(pp.param, t_min, t_max)));
+        }
     }
     const std::vector<bool> on_curve(result_params.size(), true);
 

--- a/src/entities/pd.cpp
+++ b/src/entities/pd.cpp
@@ -50,14 +50,16 @@ i_ent::RawEntityPD::RawEntityPD(
     : type(other.type),
       de_pointer(other.de_pointer),
       sequence_number(other.sequence_number),
-      data(other.data) {}
+      data(other.data),
+      data_types(other.data_types) {}
 
 i_ent::RawEntityPD::RawEntityPD(
         RawEntityPD&& other) noexcept
     : type(other.type),
       de_pointer(other.de_pointer),
       sequence_number(other.sequence_number),
-      data(std::move(other.data)) {}
+      data(std::move(other.data)),
+      data_types(std::move(other.data_types)) {}
 
 i_ent::RawEntityPD& i_ent::RawEntityPD::operator=(
         const RawEntityPD& other) {
@@ -66,6 +68,7 @@ i_ent::RawEntityPD& i_ent::RawEntityPD::operator=(
         de_pointer = other.de_pointer;
         sequence_number = other.sequence_number;
         data = other.data;
+        data_types = other.data_types;
     }
     return *this;
 }
@@ -77,6 +80,7 @@ i_ent::RawEntityPD& i_ent::RawEntityPD::operator=(
         de_pointer = other.de_pointer;
         sequence_number = other.sequence_number;
         data = std::move(other.data);
+        data_types = std::move(other.data_types);
     }
     return *this;
 }
@@ -85,31 +89,20 @@ i_ent::RawEntityPD& i_ent::RawEntityPD::operator=(
 
 i_ent::RawEntityPD i_ent::ToRawEntityPD(
         const std::vector<std::string>& lines,
-        const char p_delim, const char r_delim) {
-    i_ent::RawEntityPD ep;
-
-    // シーケンス番号を取得
-    auto sequence_number = iu::GetSequenceNumber(lines[0]);
-    // DEポインタを取得
-    auto de_pointer = iu::GetDEPointer(lines[0]);
-
-    // 各行のデータ部のみを取得
-    std::vector<std::string> data_lines {};
-    for (const auto& line : lines) {
-        // データ部のみを取得し、追加
-        std::string data = iu::GetDataPart(line, SectionType::kParameter);
-        data_lines.push_back(data);
-    }
-    // データ部をパラメータ区切り文字で分割
+        const char p_delim, const char r_delim,
+        const unsigned int de_pointer, const unsigned int sequence_number) {
+    // データ部 (各行の先頭kColDEPointer-1文字) をパラメータ区切り文字で分割する.
+    // 生の行をそのまま渡し、ParseFreeFormattedData内で切り詰めることで、
+    // 行ごとの部分文字列確保 (GetDataPart) を避ける.
     std::vector<std::string> data = iu::ParseFreeFormattedData(
-            data_lines, p_delim, r_delim);
+            lines, p_delim, r_delim, iio::kColDEPointer - 1);
 
     // エンティティタイプを取得
     auto type = i_ent::ToEntityType(std::stoi(data[0]));
     if (!type.has_value()) {
         throw iio::TypeConversionError(
                 "Invalid entity type: " + std::to_string(std::stoi(data[0])) +
-                " on line " + std::to_string(ep.sequence_number) +
+                " on line " + std::to_string(sequence_number) +
                 " of the Parameter Data section");
     }
 
@@ -117,6 +110,15 @@ i_ent::RawEntityPD i_ent::ToRawEntityPD(
         type.value(), de_pointer, sequence_number,
         // 1つ目の要素はエンティティタイプなので除外
         std::vector<std::string>(data.begin() + 1, data.end()));
+}
+
+i_ent::RawEntityPD i_ent::ToRawEntityPD(
+        const std::vector<std::string>& lines,
+        const char p_delim, const char r_delim) {
+    // lines[0]からDEポインタ・シーケンス番号を抽出して5引数版へ委譲する
+    return ToRawEntityPD(lines, p_delim, r_delim,
+                         iu::GetDEPointer(lines[0]),
+                         iu::GetSequenceNumber(lines[0]));
 }
 
 
@@ -329,6 +331,8 @@ bool TryAppendString(igesio::IGESParameterVector& params, const std::string& str
 igesio::IGESParameterVector
 i_ent::ToIGESParameterVector(const RawEntityPD& pd) {
     IGESParameterVector params;
+    // パラメータ数は既知なので事前にreserveし、成長時の再確保を避ける
+    params.reserve(pd.data.size());
     for (const auto& str : pd.data) {
         if (str.empty()) {
             // 空のパラメータの場合は、とりあえずStringのデフォルト値を追加

--- a/src/entities/pd.cpp
+++ b/src/entities/pd.cpp
@@ -255,6 +255,77 @@ std::vector<unsigned int> i_ent::GetChildDEPointer(
     }
 }
 
+namespace {
+
+/// @brief パラメータ文字列の推定型
+enum class ParamKind { kInteger, kReal, kString, kLanguage };
+
+/// @brief パラメータ文字列の内容から型を1パスで推定する
+/// @param str 非空のパラメータ文字列
+/// @return 推定した型
+/// @note 'H'を含めばString、'.'/'E'/'D'を含めばReal、数字と符号のみならInteger、
+///       それ以外はLanguageと推定する. 推定が外れても結果は呼び出し側の
+///       フォールバックで正される (誤推定時のみ無駄な例外が1回生じる).
+ParamKind ClassifyParameter(const std::string& str) {
+    bool has_real_marker = false;  // '.'/'E'/'D'のいずれかを含むか
+    bool only_int_chars = true;    // 数字・符号・空白のみで構成されるか
+    for (const char c : str) {
+        if (c == 'H') return ParamKind::kString;
+        if (c == '.' || c == 'E' || c == 'D') {
+            has_real_marker = true;
+        } else if (!(c >= '0' && c <= '9') && c != '+' && c != '-' && c != ' ') {
+            only_int_chars = false;
+        }
+    }
+    if (has_real_marker) return ParamKind::kReal;
+    if (only_int_chars) return ParamKind::kInteger;
+    return ParamKind::kLanguage;
+}
+
+/// @brief 整数への変換を試み、成功すればparamsへ追加する
+/// @param[out] params 追加先のパラメータベクタ
+/// @param str 変換する文字列
+/// @return 変換に成功した場合true、失敗した場合false
+bool TryAppendInteger(igesio::IGESParameterVector& params, const std::string& str) {
+    try {
+        auto [value, format] = igesio::FromIgesIntegerWithFormat(str, std::nullopt);
+        params.push_back(value, format);
+        return true;
+    } catch (const igesio::TypeConversionError&) {
+        return false;
+    }
+}
+
+/// @brief 実数への変換を試み、成功すればparamsへ追加する
+/// @param[out] params 追加先のパラメータベクタ
+/// @param str 変換する文字列
+/// @return 変換に成功した場合true、失敗した場合false
+bool TryAppendReal(igesio::IGESParameterVector& params, const std::string& str) {
+    try {
+        auto [value, format] = igesio::FromIgesRealWithFormat(str, std::nullopt);
+        params.push_back(value, format);
+        return true;
+    } catch (const igesio::TypeConversionError&) {
+        return false;
+    }
+}
+
+/// @brief 文字列(H付)への変換を試み、成功すればparamsへ追加する
+/// @param[out] params 追加先のパラメータベクタ
+/// @param str 変換する文字列
+/// @return 変換に成功した場合true、失敗した場合false
+bool TryAppendString(igesio::IGESParameterVector& params, const std::string& str) {
+    try {
+        auto [value, format] = igesio::FromIgesStringWithFormat(str, std::nullopt);
+        params.push_back(value, format);
+        return true;
+    } catch (const igesio::TypeConversionError&) {
+        return false;
+    }
+}
+
+}  // namespace
+
 igesio::IGESParameterVector
 i_ent::ToIGESParameterVector(const RawEntityPD& pd) {
     IGESParameterVector params;
@@ -266,26 +337,28 @@ i_ent::ToIGESParameterVector(const RawEntityPD& pd) {
             continue;
         }
 
-        try {  // 整数型への変換を試みる
-            auto [value, format] = igesio::FromIgesIntegerWithFormat(str, std::nullopt);
-            params.push_back(value, format);
-            continue;
-        } catch (const igesio::TypeConversionError&) {}
-
-        try {  // 実数型への変換を試みる
-            auto [value, format] = igesio::FromIgesRealWithFormat(str, std::nullopt);
-            params.push_back(value, format);
-            continue;
-        } catch (const igesio::TypeConversionError&) {}
-
-        try {  // 文字列型への変換を試みる
-            auto [value, format] = igesio::FromIgesStringWithFormat(str, std::nullopt);
-            params.push_back(value, format);
-            continue;
-        } catch (const igesio::TypeConversionError&) {}
-
-        auto [value, format] = igesio::FromIgesLanguageWithFormat(str, std::nullopt);
-        params.push_back(value, format);
+        // 内容から型を推定し、推定した型から順に変換を試みる.
+        // 推定が正しければ最初の試行で成功し、実数・文字列を整数として試す
+        // 従来の例外駆動判定で生じていた無駄なthrowを回避する.
+        // フォールスルー順は従来同様 整数→実数→文字列→Languageを維持する.
+        // 推定でスキップする変換は当該入力では必ず失敗するため、結果は不変.
+        switch (ClassifyParameter(str)) {
+            case ParamKind::kInteger:
+                if (TryAppendInteger(params, str)) continue;
+                [[fallthrough]];
+            case ParamKind::kReal:
+                if (TryAppendReal(params, str)) continue;
+                [[fallthrough]];
+            case ParamKind::kString:
+                if (TryAppendString(params, str)) continue;
+                [[fallthrough]];
+            case ParamKind::kLanguage:
+            default: {
+                auto [value, format] = igesio::FromIgesLanguageWithFormat(
+                        str, std::nullopt);
+                params.push_back(value, format);
+            }
+        }
     }
 
     return params;

--- a/src/entities/surfaces/trimmed_surface.cpp
+++ b/src/entities/surfaces/trimmed_surface.cpp
@@ -487,8 +487,12 @@ void TrimmedSurface::RemoveInnerBoundaryAt(size_t index) {
 
 
 /**
- * private methods
+ * キャッシュの構築
  */
+
+void TrimmedSurface::PrepareGeometryCache() const {
+    BuildDomainCache();
+}
 
 void TrimmedSurface::BuildDomainCache() const {
     if (domain_cache_) return;

--- a/src/models/assembly.cpp
+++ b/src/models/assembly.cpp
@@ -170,6 +170,35 @@ void Assembly::SetPointerIfUnset(std::shared_ptr<entities::EntityBase> entity) {
     }
 }
 
+void Assembly::AddEntities(
+        const std::vector<std::shared_ptr<entities::EntityBase>>& entities) {
+    // 事前にreserveしてリハッシュを抑える
+    entities_.reserve(entities_.size() + entities.size());
+
+    // まず全エンティティをマップとルート逆引きインデックスへ登録する
+    for (const auto& entity : entities) {
+        if (!entity) {
+            throw std::invalid_argument("Entity pointer is null");
+        }
+        const auto id = entity->GetID();
+        entities_[id] = entity;
+        RegisterInIndex(id, this);
+    }
+
+    // 全件登録後に参照解決を1回だけ行う (O(エンティティ数+参照数)).
+    // 各エンティティの未解決参照のうち、このノードが持つものを解決することで、
+    // 前方参照・後方参照の双方が一括で解決される. 1件ずつAddEntityを呼ぶ場合に
+    // 生じる挿入ごとの全件走査 (O(N^2)) を回避するための経路.
+    for (const auto& [id, ent] : entities_) {
+        for (const auto& rid : ent->GetUnresolvedReferences()) {
+            auto it = entities_.find(rid);
+            if (it != entities_.end()) {
+                ent->SetUnresolvedReference(it->second);
+            }
+        }
+    }
+}
+
 bool Assembly::AreAllReferencesSet() const {
     auto unresolved = GetUnresolvedReferences();
     return unresolved.empty();

--- a/src/models/assembly.cpp
+++ b/src/models/assembly.cpp
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "igesio/common/parallel.h"
 #include "igesio/entities/views/curve_view.h"
 #include "igesio/entities/views/surface_view.h"
 
@@ -693,4 +694,16 @@ Assembly::GetWorldBoundingBox() const {
     if (zero_axes >= 2) return std::nullopt;
 
     return numerics::BoundingBox(lo, hi);
+}
+
+void Assembly::PrepareGeometryCaches(const bool recursive) const {
+    // 自ノード(必要なら全子孫)のエンティティをフラットに収集する.
+    // 各PrepareGeometryCacheは互いに独立 (それぞれ自身のキャッシュのみ書き込む) なので、
+    // ロックなしで並列実行できる. ParallelForEachが戻る前に全ワーカーを待ち合わせる.
+    const auto entities = FindEntities(
+            [](const i_ent::EntityBase&) { return true; }, recursive);
+    igesio::ParallelForEach(
+            entities, [](const std::shared_ptr<i_ent::EntityBase>& e) {
+        e->PrepareGeometryCache();
+    });
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -382,7 +382,8 @@ void ReconstructOmittedBaseCurves(i_model::Assembly& root) {
 
 
 i_model::IgesData igesio::ConvertFromIntermediate(
-        const models::IntermediateIgesData& intermediate) {
+        const models::IntermediateIgesData& intermediate,
+        const bool prepare_caches) {
     i_model::IgesData iges;
     iges.description = intermediate.start_section;
     iges.global_section = intermediate.global_section;
@@ -474,14 +475,20 @@ i_model::IgesData igesio::ConvertFromIntermediate(
     // 読み込んだエンティティから初期ツリー(子Assembly階層)を導出する
     BuildInitialTree(iges.Root());
 
+    if (prepare_caches) {
+        // エンティティのキャッシュを事前構築する
+        iges.Root().PrepareGeometryCaches(true);
+    }
+
     return iges;
 }
 
 i_model::IgesData igesio::ReadIges(const std::string& file_path,
-                                   const bool validate_strictly) {
+                                   const bool validate_strictly,
+                                   const bool prepare_caches) {
     // IGESファイルを読み込み、中間データ構造を生成
     auto intermediate = ReadIgesIntermediate(file_path, validate_strictly);
 
     // 中間データ構造からIgesDataクラスを生成
-    return ConvertFromIntermediate(intermediate);
+    return ConvertFromIntermediate(intermediate, prepare_caches);
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -8,10 +8,12 @@
 #include "igesio/reader.h"
 
 #include <array>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "igesio/utils/iges_string_utils.h"
@@ -403,29 +405,41 @@ i_model::IgesData igesio::ConvertFromIntermediate(
                 iges_id, static_cast<uint16_t>(de.entity_type), de_pointer);
     }
 
-    // DEとPDを組み合わせてエンティティを生成し、IgesDataに追加
+    // PDのシーケンス番号からインデックスを引く対応表をO(N)で構築する
+    // (重複シーケンス番号は先頭を優先し、現行のfind_ifと同一挙動とする)
+    std::unordered_map<unsigned int, std::size_t> pd_seq_to_index;
+    pd_seq_to_index.reserve(intermediate.parameter_data_section.size());
+    for (std::size_t i = 0; i < intermediate.parameter_data_section.size(); ++i) {
+        pd_seq_to_index.emplace(
+                intermediate.parameter_data_section[i].sequence_number, i);
+    }
+
+    // 生成したエンティティを一旦集め、ループ後に一括登録する
+    // (1件ずつAddEntityすると内部の参照解決がO(N^2)になるため)
+    std::vector<std::shared_ptr<entities::EntityBase>> created;
+    created.reserve(intermediate.directory_entry_section.size());
+
+    // DEとPDを組み合わせてエンティティを生成する
     for (const auto& de : intermediate.directory_entry_section) {
-        // pd_pointerとシーケンス番号が一致するPDを探す
+        // pd_pointerとシーケンス番号が一致するPDを直接引く
         auto pd_pointer = de.parameter_data_pointer;
-        auto pd_it = std::find_if(
-                intermediate.parameter_data_section.begin(),
-                intermediate.parameter_data_section.end(),
-                [pd_pointer](const entities::RawEntityPD& pd) {
-                    return pd.sequence_number == pd_pointer;
-                });
-        if (pd_it == intermediate.parameter_data_section.end()) {
+        auto pd_it = pd_seq_to_index.find(pd_pointer);
+        if (pd_it == pd_seq_to_index.end()) {
             throw iio::DataFormatError(
                     "Parameter data record with pointer " +
                     std::to_string(pd_pointer) +
                     " not found for directory entry with sequence number " +
                     std::to_string(de.sequence_number) + ".");
         }
-        auto pd = *pd_it;
+        const auto& pd = intermediate.parameter_data_section[pd_it->second];
 
         // DEとPDを組み合わせてエンティティを生成
+        // (内訳計測のためToIGESParameterVectorとCreateEntityを分けて呼ぶ)
         try {
-            auto entity = entities::EntityFactory::CreateEntity(de, pd, de2id, iges_id);
-            iges.Root().AddEntity(entity);
+            auto params = entities::ToIGESParameterVector(pd);
+            auto entity = entities::EntityFactory::CreateEntity(
+                    de, params, de2id, iges_id);
+            created.push_back(std::move(entity));
         } catch (const std::out_of_range& e) {
             // エンティティがIGESファイル内に存在しないエンティティを参照している場合
             throw iio::DataFormatError(
@@ -442,6 +456,9 @@ i_model::IgesData igesio::ConvertFromIntermediate(
                     "Details: " + std::string(e.what()));
         }
     }
+
+    // 生成した全エンティティを一括登録する (参照解決は内部で1回だけ行われる)
+    iges.Root().AddEntities(created);
 
     // ベース曲線Bが省略されたType 142 (CATIA等) について、参照解決済みの
     // モデル空間曲線Cと曲面SからB = S^{-1}∘Cを再構築する.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "igesio/utils/iges_string_utils.h"
@@ -183,6 +184,8 @@ iio::IgesReader::ReadParameterDataRecord() {
 
     // DEポインタを取得
     auto de_pointer = i_util::GetDEPointer(std::get<0>(line.value()));
+    // シーケンス番号はGetLineが算出済み (末尾7桁) なので再抽出しない
+    const unsigned int sequence_number = std::get<2>(line.value());
 
     // データ部を取得
     std::vector<std::string> lines = {std::get<0>(line.value())};
@@ -206,8 +209,10 @@ iio::IgesReader::ReadParameterDataRecord() {
     // データが取得できない場合は終了
     if (lines.empty()) return std::nullopt;
 
+    // 既知のDEポインタ・シーケンス番号を渡し、lines[0]からの再抽出を省く
     return i_ent::ToRawEntityPD(
-            lines, parameter_delimiter_, record_delimiter_);
+            lines, parameter_delimiter_, record_delimiter_,
+            de_pointer, sequence_number);
 }
 
 std::optional<std::array<unsigned int, 4>>
@@ -307,10 +312,13 @@ i_model::IntermediateIgesData igesio::ReadIgesIntermediate(
     }
 
     // パラメータデータセクションを読み込む
+    // PDレコード数はDEレコード数と一致するため事前にreserveする
+    data.parameter_data_section.reserve(data.directory_entry_section.size());
     while (true) {
         auto pd = reader.ReadParameterDataRecord();
         if (!pd.has_value()) break;  // std::nulloptの場合は終了
-        data.parameter_data_section.push_back(pd.value());
+        // RawEntityPDをムーブして格納し、全パラメータ文字列の複製を避ける
+        data.parameter_data_section.push_back(std::move(*pd));
     }
 
     // ターミネートセクションを読み込む
@@ -436,9 +444,8 @@ i_model::IgesData igesio::ConvertFromIntermediate(
         // DEとPDを組み合わせてエンティティを生成
         // (内訳計測のためToIGESParameterVectorとCreateEntityを分けて呼ぶ)
         try {
-            auto params = entities::ToIGESParameterVector(pd);
             auto entity = entities::EntityFactory::CreateEntity(
-                    de, params, de2id, iges_id);
+                    de, entities::ToIGESParameterVector(pd), de2id, iges_id);
             created.push_back(std::move(entity));
         } catch (const std::out_of_range& e) {
             // エンティティがIGESファイル内に存在しないエンティティを参照している場合

--- a/src/utils/iges_binary_reader.cpp
+++ b/src/utils/iges_binary_reader.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "igesio/utils/iges_string_utils.h"
@@ -69,9 +70,10 @@ DetectLineBreakChar(const std::array<char, 2>& bytes, const std::size_t bytes_re
 /// @throw igesio::LineFormatError kMaxColumn+1文字目までに
 ///        改行文字が見つからなかった場合
 /// @note 改行文字の末端までfsを読込 (次のfs.get()で次の行の1文字目を取得可能)
-std::vector<char>
+std::string
 ReadToNextLineBreak(std::ifstream& fs, const std::vector<char>& line_break) {
-    std::vector<char> line = {};
+    std::string line;
+    line.reserve(iio::kMaxColumn);
     std::size_t pos = 0;
     char c;
     bool line_break_found = false;
@@ -107,21 +109,16 @@ ReadToNextLineBreak(std::ifstream& fs, const std::vector<char>& line_break) {
     if (!line_break_found) {
         if (fs.eof()) {
             // EOFに達している場合、ターミネートセクションであればエラーを出さない
-            std::string line_s(line.begin(), line.end());
             try {
-                auto section_type = i_util::GetSectionType(line_s);
-                if (section_type == SType::kTerminate) return line;
+                if (i_util::GetSectionType(line) == SType::kTerminate) return line;
             } catch (...) {}
             // 何らかのエラーが発生した場合は、以下のエラーを投げる
         }
 
         // kMaxColumn+1文字目までに改行文字が見つからなかった場合
-        // 末尾に\0を追加してエラー
-        line.push_back('\0');
         throw iio::LineFormatError(
             "The line break character was not found within " +
-            std::to_string(iio::kMaxColumn) + " characters: " +
-            line.data());
+            std::to_string(iio::kMaxColumn) + " characters: " + line);
     }
     return line;
 }
@@ -250,11 +247,10 @@ std::tuple<std::string, ::SType, unsigned int> IBReader::GetLine() {
 
     // 次の改行文字まで読み込む (必ずしもkMaxColumn文字ではない)
     try {
-        auto line_v = ReadToNextLineBreak(file_, line_break_);
-        std::string line(line_v.begin(), line_v.end());
+        std::string line = ReadToNextLineBreak(file_, line_break_);
 
         // セクションの型とシーケンス番号を取得する (同時に行数などもチェックされる)
-        auto section_type = i_util::GetSectionType(line, IsCompressed());
+        const auto section_type = i_util::GetSectionType(line, IsCompressed());
         unsigned int sequence_number = 0;
         if (section_type != SType::kData) {
             // 圧縮形式のデータセクション以外の場合はシーケンス番号を取得
@@ -264,7 +260,7 @@ std::tuple<std::string, ::SType, unsigned int> IBReader::GetLine() {
         // セクションの順序とシーケンス番号を更新する
         UpdateSectionInfo(section_type, sequence_number);
 
-        return {line, section_type, sequence_number};
+        return {std::move(line), section_type, sequence_number};
     } catch (const iio::LineFormatError& e) {
         has_error_occurred_ = true;
         throw e;

--- a/src/utils/iges_string_utils.cpp
+++ b/src/utils/iges_string_utils.cpp
@@ -215,13 +215,17 @@ std::size_t FindParameterEnd(const std::string& connected, const std::size_t pos
 
 std::vector<std::string> i_util::ParseFreeFormattedData(
         const std::vector<std::string>& lines,
-        const char p_delim, const char r_delim) {
-    // 全ての文字列を結合する (事前にreserveしてコピーを抑える)
+        const char p_delim, const char r_delim,
+        const std::size_t data_part_width) {
+    // 各行のデータ部 (先頭data_part_width文字; 既定は行全体) を結合する.
+    // 生の行を渡してもらい、ここで切り詰めることで呼び出し側の中間コピーを避ける.
     std::size_t total = 0;
-    for (const auto& line : lines) total += line.size();
+    for (const auto& line : lines) total += std::min(line.size(), data_part_width);
     std::string connected;
     connected.reserve(total);
-    for (const auto& line : lines) connected += line;
+    for (const auto& line : lines) {
+        connected.append(line.data(), std::min(line.size(), data_part_width));
+    }
 
     const std::string delimiters{p_delim, r_delim};
     const std::size_t n = connected.size();

--- a/src/utils/iges_string_utils.cpp
+++ b/src/utils/iges_string_utils.cpp
@@ -181,69 +181,34 @@ std::string i_util::GetDataPart(const std::string& line,
 
 namespace {
 
-/// @brief 与えられた文字列の冒頭にあるH文字列の長さを取得する
-/// @param str 文字列
-/// @return H文字列の長さ
-/// @note 与えられた文字列の先頭にH文字列が存在しない場合 ('12,4Hello'等) は0を返す.
-///       具体的な処理としては、strに初めてHが現れるまでの文字が、
-///       すべて数字であればその数値を返し、それ以外の場合は0を返す.
-int GetHStringLength(const std::string& str) {
-    // 文字列中にHが存在しない場合は0を返す
-    auto h_pos = str.find('H');
-    if (h_pos == std::string::npos) return 0;
+/// @brief 連結データの指定位置から始まるパラメータの終端位置を求める
+/// @param connected 連結済みのデータ文字列
+/// @param pos 走査開始位置 (先頭の空白は呼び出し側で除去済みであること)
+/// @param delimiters パラメータ区切り文字とレコード区切り文字を並べた文字列
+/// @return パラメータの終端=区切り文字の位置. 区切り文字が見つからない場合は
+///         std::string::npos
+/// @note H文字列 (`<数字>H<内容>`) は内容に区切り文字を含みうるため、宣言長から
+///       終端を直接算出する. それ以外は次の区切り文字までをパラメータとする.
+///       H判定は「先頭の数字列の直後が'H'か」を有界に確認する (遠方のHは探さない).
+///       宣言長が0 ('0H'等) の場合は従来通り非H文字列として扱う.
+std::size_t FindParameterEnd(const std::string& connected, const std::size_t pos,
+                             const std::string& delimiters) {
+    // 先頭の数字列を走査する
+    std::size_t d = pos;
+    while (d < connected.size() && '0' <= connected[d] && connected[d] <= '9') ++d;
 
-    // 最初にHが現れるまでの文字がすべて数字かどうかを確認
-    int h_length = 0;
-    for (size_t i = 0; i < h_pos; ++i) {
-        // 最初のHまでの文字列に数字以外の文字が含まれている場合は0を返す
-        if (!('0' <= str[i] && str[i] <= '9')) return 0;
-        h_length = h_length * 10 + (str[i] - '0');
-    }
-    return h_length;
-}
-
-/// @brief 自由形式のデータから1つのパラメータを取得する
-/// @param str 文字列
-/// @param p_delim パラメータ区切り文字
-/// @param r_delim レコード区切り文字
-/// @return 文字列のペア:
-///   - std::string: パラメータの文字列
-///   - std::string: 残った文字列
-/// @note 例えば`"12,4Hello,3.14"`のような文字列を与えた場合、
-///       `"12"`と`",4Hello,3.14"`を返す. また、パラメータの前に半角スペースがある場合、
-///       例えば`"   12,4Hello,3.14"`のような文字列を与えた場合には、それらを削除して
-///       `"12"`と`",4Hello,3.14"`を返す.
-/// @throw igesio::SectionFormatError 区切り文字が存在しない場合、
-///        不正な文字列ステートメント（H文字列）が含まれる場合
-std::pair<std::string, std::string>
-GetParameterString(const std::string& str, const char p_delim, const char r_delim) {
-    // 冒頭のスペースを削除
-    auto tstr = i_util::ltrim(str);
-
-    // 冒頭のパラメータの終端位置を取得 (end of parameter)
-    int eop = 0;
-    auto h_length = GetHStringLength(tstr);
-    if (h_length == 0) {
-        // 現在のパラメータはH文字列ではない -> 区切り文字まで取得
-        eop = std::min(tstr.find(p_delim), tstr.find(r_delim));
-    } else {
-        // 現在のパラメータはH文字列 -> H文字列分だけ取得
-        eop = tstr.find('H') + h_length + 1;
+    // 数字列の直後が'H'ならH文字列 (宣言長が正のときのみ)
+    if (d > pos && d < connected.size() && connected[d] == 'H') {
+        std::size_t h_length = 0;
+        for (std::size_t i = pos; i < d; ++i) {
+            h_length = h_length * 10 + (connected[i] - '0');
+        }
+        // 内容 [d+1, d+1+h_length) の直後を終端とする (内容中の区切り文字は飛ばす)
+        if (h_length > 0) return d + 1 + h_length;
     }
 
-    if (eop == std::string::npos) {
-        // 区切り文字が存在しない場合はエラー
-        throw iio::SectionFormatError(
-                "No delimiter exists in the string: '" + tstr + "'");
-    } else if (eop + 1 > tstr.size() ||
-               tstr[eop] != p_delim && tstr[eop] != r_delim) {
-        // パラメータ終端位置の後ろに区切り文字がない場合はエラー
-        throw iio::SectionFormatError(
-                "No delimiter exists after the parameter (at pos " +
-                std::to_string(eop + 1) + "): '" + tstr + "'");
-    }
-
-    return {tstr.substr(0, eop), tstr.substr(eop)};
+    // 非H文字列: 次の区切り文字までをパラメータとする
+    return connected.find_first_of(delimiters, pos);
 }
 
 }  // namespace
@@ -251,23 +216,49 @@ GetParameterString(const std::string& str, const char p_delim, const char r_deli
 std::vector<std::string> i_util::ParseFreeFormattedData(
         const std::vector<std::string>& lines,
         const char p_delim, const char r_delim) {
-    // 全ての文字列を単純に結合
-    std::string connected = "";
+    // 全ての文字列を結合する (事前にreserveしてコピーを抑える)
+    std::size_t total = 0;
+    for (const auto& line : lines) total += line.size();
+    std::string connected;
+    connected.reserve(total);
     for (const auto& line : lines) connected += line;
 
-    // データごとに読み込み
-    std::vector<std::string> result = {};
+    const std::string delimiters{p_delim, r_delim};
+    const std::size_t n = connected.size();
+
+    // カーソルを前進させながらパラメータを切り出す (残り文字列をコピーしない)
+    std::vector<std::string> result;
+    std::size_t pos = 0;
     while (true) {
-        auto [param, rest] = GetParameterString(connected, p_delim, r_delim);
-        result.push_back(param);
+        // 先頭の空白をスキップする (従来のltrim相当)
+        while (pos < n && connected[pos] == ' ') ++pos;
+
+        // パラメータの終端 (区切り文字の位置) を求める
+        const std::size_t eop = FindParameterEnd(connected, pos, delimiters);
+        if (eop == std::string::npos) {
+            // 区切り文字が存在しない場合はエラー
+            throw iio::SectionFormatError(
+                    "No delimiter exists in the string: '" +
+                    connected.substr(pos) + "'");
+        } else if (eop >= n ||
+                   (connected[eop] != p_delim && connected[eop] != r_delim)) {
+            // パラメータ終端の後ろに区切り文字がない場合はエラー
+            // (H文字列の宣言長が実体を超える場合などに該当)
+            throw iio::SectionFormatError(
+                    "No delimiter exists after the parameter (at pos " +
+                    std::to_string(eop) + "): '" + connected.substr(pos) + "'");
+        }
+
+        // パラメータを取得する
+        result.push_back(connected.substr(pos, eop - pos));
 
         // 区切り文字がレコード区切り文字であれば終了
-        if (rest[0] == r_delim) break;
+        if (connected[eop] == r_delim) break;
 
-        // 区切り文字を削除
-        connected = rest.substr(1);
-        if (connected.empty()) {
-            // 文字列がなくなるまでにレコード区切り文字が存在しない場合はエラー
+        // パラメータ区切り文字を飛ばして次のパラメータへ
+        pos = eop + 1;
+        if (pos >= n) {
+            // レコード区切り文字が現れないまま文字列が尽きた場合はエラー
             throw iio::SectionFormatError(
                     "No record delimiter '" + std::string(1, r_delim) +
                     "' exists in the string: '" + connected + "'");

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SOURCES
     test_serialization_ToIgesXxx.cpp
     test_iges_parameter_vector.cpp
     test_validation_result.cpp
+    test_parallel.cpp
 )
 
 add_executable(test_common ${TEST_SOURCES})

--- a/tests/common/test_parallel.cpp
+++ b/tests/common/test_parallel.cpp
@@ -1,0 +1,221 @@
+/**
+ * @file common/test_parallel.cpp
+ * @brief common/parallel.hのテスト
+ * @author Yayoi Habami
+ * @date 2026-06-02
+ * @copyright 2026 Yayoi Habami
+ *
+ * テスト対象:
+ *   - igesio::ParallelFor(count, func, min_parallel_size)
+ *   - igesio::ParallelForEach(items, func, min_parallel_size)
+ *
+ * 各環境 (Windows/macOS/Linux × GCC/Clang/MSVC) でスレッドバックエンドが正しく
+ * 動作することの確認を主眼とする。スレッド数や実際に並列実行されたか否かは環境依存
+ * かつ非決定的なため検証しない (フレーキー回避)。代わりに以下を検証する:
+ *   - 各インデックス/要素がちょうど一度ずつ処理されること (網羅性)
+ *   - 競合状態がないこと (atomic合計・独立スロット書き込みの整合)
+ *   - funcの例外がデッドロックせず呼び出し側へ伝播すること
+ *
+ * TODO: 実際に複数スレッドで同時実行されたことの直接検証は行わない
+ *       (タイミング依存でフレーキーになり、単一コア環境では成立しないため)。
+ */
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "igesio/common/parallel.h"
+
+namespace {
+
+/// @brief 並列パスを強制する閾値 (count>0なら必ず並列分岐を試みる)
+constexpr std::size_t kForceParallel = 0;
+
+/// @brief 直列パスを強制する閾値 (実用上ありえない大きさ)
+constexpr std::size_t kForceSerial = std::numeric_limits<std::size_t>::max();
+
+/// @brief ParallelForEach検証用の作業単位
+/// @note 入力inputから結果resultを計算する。各インスタンスは自身のresultのみ
+///       書き込むため、ロックなしで並列処理できる (Assemblyのキャッシュ構築と同型)。
+struct Worker {
+    std::size_t input;
+    std::size_t result = 0;
+    /// @brief result = input^2 を計算する
+    void Compute() { result = input * input; }
+};
+
+}  // namespace
+
+
+
+/**
+ * ParallelFor: 正常系 (網羅性・競合なし)
+ */
+
+// 代表値: 各インデックスがちょうど一度ずつ呼ばれる (二重呼び出しをatomicで検出)
+TEST(ParallelForTest, EachIndexVisitedExactlyOnce) {
+    constexpr std::size_t kCount = 1000;
+    std::vector<std::atomic<int>> visits(kCount);
+    for (auto& v : visits) v.store(0, std::memory_order_relaxed);
+
+    igesio::ParallelFor(kCount, [&visits](std::size_t i) {
+        visits[i].fetch_add(1, std::memory_order_relaxed);
+    }, kForceParallel);
+
+    for (std::size_t i = 0; i < kCount; ++i) {
+        EXPECT_EQ(visits[i].load(std::memory_order_relaxed), 1)
+                << "index " << i;
+    }
+}
+
+// 共有atomicへの加算が競合なく集計される (取りこぼし・重複がないこと)
+TEST(ParallelForTest, AtomicSumUnderContention) {
+    constexpr std::size_t kCount = 10000;
+    std::atomic<std::uint64_t> sum{0};
+
+    igesio::ParallelFor(kCount, [&sum](std::size_t i) {
+        sum.fetch_add(i, std::memory_order_relaxed);
+    }, kForceParallel);
+
+    // 0 + 1 + ... + (kCount-1)
+    const std::uint64_t expected = kCount * (kCount - 1) / 2;
+    EXPECT_EQ(sum.load(), expected);
+}
+
+// 直列パスと並列パスで結果が一致する
+TEST(ParallelForTest, SerialAndParallelProduceSameResult) {
+    constexpr std::size_t kCount = 500;
+    std::vector<int> serial(kCount, 0);
+    std::vector<int> parallel(kCount, 0);
+
+    igesio::ParallelFor(kCount, [&serial](std::size_t i) {
+        serial[i] = static_cast<int>(i * 3);
+    }, kForceSerial);
+    igesio::ParallelFor(kCount, [&parallel](std::size_t i) {
+        parallel[i] = static_cast<int>(i * 3);
+    }, kForceParallel);
+
+    EXPECT_EQ(serial, parallel);
+}
+
+
+
+/**
+ * ParallelFor: 境界値
+ */
+
+// count=0: funcは一度も呼ばれず、ハングしない
+TEST(ParallelForTest, Count0NeverCallsFunc) {
+    std::atomic<int> calls{0};
+    igesio::ParallelFor(0, [&calls](std::size_t) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+    }, kForceParallel);
+    EXPECT_EQ(calls.load(), 0);
+}
+
+// count=1: funcはi=0で一度だけ呼ばれる
+TEST(ParallelForTest, Count1CallsFuncOnce) {
+    std::vector<std::size_t> seen;
+    igesio::ParallelFor(1, [&seen](std::size_t i) {
+        seen.push_back(i);
+    }, kForceParallel);
+    ASSERT_EQ(seen.size(), 1u);
+    EXPECT_EQ(seen.front(), 0u);
+}
+
+// min_parallel_size境界: 直列分岐 (count == min) でも全件処理される
+TEST(ParallelForTest, AtMinParallelSizeUsesSerialPath) {
+    constexpr std::size_t kCount = 4;
+    std::vector<int> out(kCount, 0);
+    igesio::ParallelFor(kCount, [&out](std::size_t i) {
+        out[i] = static_cast<int>(i) + 1;
+    }, /*min_parallel_size=*/kCount);  // count <= min → 直列
+    EXPECT_EQ(out, (std::vector<int>{1, 2, 3, 4}));
+}
+
+// min_parallel_size境界: 並列分岐 (count == min+1) でも全件処理される
+TEST(ParallelForTest, JustAboveMinParallelSizeUsesParallelPath) {
+    constexpr std::size_t kMin = 4;
+    constexpr std::size_t kCount = kMin + 1;
+    std::vector<int> out(kCount, 0);
+    igesio::ParallelFor(kCount, [&out](std::size_t i) {
+        out[i] = static_cast<int>(i) + 1;
+    }, /*min_parallel_size=*/kMin);  // count > min → 並列
+    EXPECT_EQ(out, (std::vector<int>{1, 2, 3, 4, 5}));
+}
+
+// ストレス: 大量要素でも全スロットが正しく書き込まれる
+TEST(ParallelForTest, LargeCountWritesAllSlots) {
+    constexpr std::size_t kCount = 100000;
+    std::vector<std::size_t> out(kCount, 0);
+    igesio::ParallelFor(kCount, [&out](std::size_t i) {
+        out[i] = i * 2;
+    }, kForceParallel);
+    for (std::size_t i = 0; i < kCount; ++i) {
+        ASSERT_EQ(out[i], i * 2) << "index " << i;
+    }
+}
+
+
+
+/**
+ * ParallelFor: 例外伝播
+ */
+
+// 並列パス: funcが投げた例外がデッドロックせず伝播する
+TEST(ParallelForTest, PropagatesExceptionFromParallelPath) {
+    EXPECT_THROW(
+        igesio::ParallelFor(1000, [](std::size_t) {
+            throw std::runtime_error("boom");
+        }, kForceParallel),
+        std::runtime_error);
+}
+
+// 直列パス: funcが投げた例外が伝播する
+TEST(ParallelForTest, PropagatesExceptionFromSerialPath) {
+    EXPECT_THROW(
+        igesio::ParallelFor(1, [](std::size_t) {
+            throw std::runtime_error("boom");
+        }, kForceSerial),
+        std::runtime_error);
+}
+
+
+
+/**
+ * ParallelForEach
+ */
+
+// 代表値: 各要素 (shared_ptr経由) が処理され、結果が正しい
+// (Assembly::PrepareGeometryCachesがe->PrepareGeometryCache()を呼ぶ構造と同型)
+TEST(ParallelForEachTest, ProcessesAllElements) {
+    constexpr std::size_t kCount = 2000;
+    std::vector<std::shared_ptr<Worker>> workers;
+    workers.reserve(kCount);
+    for (std::size_t i = 0; i < kCount; ++i) {
+        workers.push_back(std::make_shared<Worker>(Worker{i}));
+    }
+
+    igesio::ParallelForEach(workers,
+        [](const std::shared_ptr<Worker>& w) { w->Compute(); },
+        kForceParallel);
+
+    for (std::size_t i = 0; i < kCount; ++i) {
+        EXPECT_EQ(workers[i]->result, i * i) << "index " << i;
+    }
+}
+
+// 退化: 空vectorではfuncが呼ばれず、ハングしない
+TEST(ParallelForEachTest, EmptyVectorNeverCallsFunc) {
+    std::vector<int> empty;
+    std::atomic<int> calls{0};
+    igesio::ParallelForEach(empty, [&calls](const int&) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+    }, kForceParallel);
+    EXPECT_EQ(calls.load(), 0);
+}

--- a/tests/entities/CMakeLists.txt
+++ b/tests/entities/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
     curves/test_signed_curvature.cpp
     curves/test_curve_line_intersection.cpp
     curves/algorithms/test_extremal_polygon.cpp
+    curves/algorithms/test_polygonal_approximation.cpp
 
     # Structures
     structures/test_color_definition.cpp

--- a/tests/entities/curves/algorithms/test_polygonal_approximation.cpp
+++ b/tests/entities/curves/algorithms/test_polygonal_approximation.cpp
@@ -1,0 +1,421 @@
+/**
+ * @file tests/entities/curves/algorithms/test_polygonal_approximation.cpp
+ * @brief src/entities/curves/algorithms/polygonal_approximation.h のテスト
+ * @author Yayoi Habami
+ * @date 2026-06-02
+ * @copyright 2026 Yayoi Habami
+ *
+ * テスト対象 (igesio::entities):
+ *   ComputeApproximatePolygon(curve, inscribed, circumscribed, eps, max_depth)
+ *
+ * テスト曲線:
+ *   - MakeLineSegment       : Type 110 線分 (開・直線部報告なし→終了条件②)
+ *   - MakeStraightNurbs     : degree-1 NURBS 直線 (開・直線部報告あり→終了条件①)
+ *   - MakeHalfCircle        : 半円 CircularArc (開・滑らか)
+ *   - MakeFullCircle        : 全円 CircularArc (閉)
+ *   - MakeLoopArchBand1/2   : M16 由来の直線+曲線混在 閉ループ (extremal_polygon_test_curves.h)
+ *
+ * 検証方針:
+ *   頂点座標はハードコードせず、出力多角形が満たすべき性質 (構造妥当性・近似精度・
+ *   固定点保存・閉曲線終端処理・境界クランプ) を検証する。解析的に決定論的な
+ *   ケース (直線・巨大eps・max_depth=0) のみ正確なパラメータ列を固定し、特性化
+ *   (高速化リファクタでの出力不変) のロックとする。非決定論的ケースの集約
+ *   フィンガープリント採取は DISABLED_RecordFingerprints を参照。
+ *
+ * TODO:
+ *   - 異常系: ComputeApproximatePolygon は正当な入力に対し例外を投げる定義された
+ *     経路を持たない (範囲外パラメータは clamp、点評価失敗は graceful 打ち切り)。
+ *     配列長が不整合な PolygonData は operator[] による未定義動作であり契約外の
+ *     ため未カバー。
+ *   - z≠0 平面・任意方向 reference_normal の曲線は未カバー (z=0/法線(0,0,1)のみ)。
+ *   - 非決定論的ケース (一般曲線 eps=1e-3, NURBSループ) のビット一致ロックは
+ *     性質テストと DISABLED_RecordFingerprints での基準値採取に委ねる。
+ *   - max_depth 打ち切り (終了条件③) で中点距離>eps となる辺は近似精度検証
+ *     (ExpectEdgesWithinEps) の対象外。
+ */
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "igesio/common/iges_parameter_vector.h"
+#include "igesio/numerics/matrix.h"
+#include "igesio/numerics/polygon.h"
+#include "igesio/entities/interfaces/i_curve.h"
+#include "igesio/entities/curves/line.h"
+#include "igesio/entities/curves/circular_arc.h"
+#include "igesio/entities/curves/composite_curve.h"
+#include "igesio/entities/curves/rational_b_spline_curve.h"
+#include "igesio/entities/curves/algorithms.h"
+// テスト対象 (src 配下の内部ヘッダ; igesio が src を PUBLIC include に公開)
+#include "entities/curves/algorithms/polygonal_approximation.h"
+#include "entities/curves/algorithms/extremal_polygon.h"
+#include "./extremal_polygon_test_curves.h"
+
+namespace {
+
+namespace i_ent = igesio::entities;
+namespace i_num = igesio::numerics;
+namespace i_test = igesio::tests;
+using igesio::Vector2d;
+using igesio::Vector3d;
+using i_ent::CircularArc;
+using i_ent::CompositeCurve;
+using i_ent::ICurve;
+using i_ent::Line;
+using i_ent::RationalBSplineCurve;
+using i_num::PolygonData;
+
+/// @brief 円周率
+constexpr double kPi = igesio::kPi;
+/// @brief 頂点と C(param) の一致許容誤差
+constexpr double kEvalTol = 1e-9;
+/// @brief 解析解・特性化パラメータの一致許容誤差
+constexpr double kParamTol = 1e-12;
+/// @brief z=0 平面曲線の参照法線
+const Vector3d kNormalZ(0.0, 0.0, 1.0);
+
+
+
+/**
+ * テスト曲線ファクトリ
+ */
+
+/// @brief Type 110 線分 (0,0,0)-(2,1,0)。開曲線・直線部は報告しない。
+///        パラメータ範囲 [0, 1]。
+std::shared_ptr<Line> MakeLineSegment() {
+    return std::make_shared<Line>(Vector3d(0.0, 0.0, 0.0),
+                                  Vector3d(2.0, 1.0, 0.0));
+}
+
+/// @brief degree-1 の直線 NURBS (0,0,0)-(1,0,0)。開曲線で GetLinearSegments() が
+///        全範囲を覆う (終了条件①の検証用)。パラメータ範囲 [0, 1]。
+std::shared_ptr<RationalBSplineCurve> MakeStraightNurbs() {
+    return std::make_shared<RationalBSplineCurve>(
+        igesio::IGESParameterVector{
+            1, 1,                       // K (制御点数-1), M (次数)
+            true, false, true, false,   // PROP1-4 (平面/閉/多項式/周期)
+            0., 0., 1., 1.,             // ノットベクトル
+            1., 1.,                     // 重み
+            0., 0., 0.,                 // 制御点0
+            1., 0., 0.,                 // 制御点1
+            0., 1.,                     // V(0), V(1)
+            0., 0., 1.                  // 定義平面の法線
+        });
+}
+
+/// @brief 原点中心・半径1の半円 (開曲線)。パラメータ範囲 [0, π]、|C(t)|=1。
+std::shared_ptr<CircularArc> MakeHalfCircle() {
+    return std::make_shared<CircularArc>(Vector2d(0.0, 0.0), 1.0, 0.0, kPi);
+}
+
+/// @brief 原点中心・半径1の全円 (閉曲線)。パラメータ範囲 [0, 2π]、|C(t)|=1。
+std::shared_ptr<CircularArc> MakeFullCircle() {
+    return std::make_shared<CircularArc>(Vector2d(0.0, 0.0), 1.0);
+}
+
+
+
+/**
+ * 補助ルーチン
+ */
+
+/// @brief 空の多角形 (固定点を持たない insc/circ)
+PolygonData EmptyPolygon() { return PolygonData{}; }
+
+/// @brief ComputeApproximatePolygon の薄いラッパー
+PolygonData Approx(const ICurve& curve, const PolygonData& insc,
+                   const PolygonData& circ, double eps, int max_depth = 1000) {
+    return i_ent::ComputeApproximatePolygon(curve, insc, circ, eps, max_depth);
+}
+
+/// @brief 閉曲線の外包・内包多角形対 (first:外包, second:内包) を生成する
+std::pair<PolygonData, PolygonData> ExtremalPair(const ICurve& curve) {
+    return i_ent::ComputeExtremalPolygonPair(curve, 64, kNormalZ);
+}
+
+/// @brief 出力多角形の構造的整合性を検証する (P1: 構造, P2: 昇順, P3: 頂点一致)
+/// @note P3 は頂点が C(clamp(param)) に一致することを要求する。高速化で点を
+///       細分中の評価値から再利用しても、この一致が崩れないことを保証する。
+void ExpectStructurallyValid(const ICurve& curve, const PolygonData& poly) {
+    ASSERT_EQ(poly.vertices.size(), poly.on_curve.size());
+    ASSERT_EQ(poly.vertices.size(), poly.curve_params.size());
+    EXPECT_GE(poly.Count(), 2);
+
+    const auto [t_min, t_max] = curve.GetParameterRange();
+    const size_t n = poly.vertices.size();
+    double last = -std::numeric_limits<double>::infinity();
+    for (size_t i = 0; i < n; ++i) {
+        const Vector3d& v = poly.vertices[i];
+        EXPECT_TRUE(std::isfinite(v.x()) && std::isfinite(v.y()) &&
+                    std::isfinite(v.z())) << "vertex " << i << " not finite";
+        // 全頂点が on_curve=true であること
+        EXPECT_TRUE(poly.on_curve[i]) << "on_curve false at " << i;
+        // パラメータは非減少であること
+        const double u = poly.curve_params[i];
+        EXPECT_GE(u, last) << "curve_params not ascending at " << i;
+        last = u;
+        // 頂点が C(clamp(param)) に一致すること
+        const Vector3d on = curve.GetPointAt(std::clamp(u, t_min, t_max));
+        EXPECT_LE((v - on).norm(), kEvalTol)
+                << "vertex != C(clamp(param)) at " << i;
+    }
+}
+
+/// @brief 各辺の近似精度を検証する (P4: 直線部内 or 中点距離≤eps)
+/// @note 閉曲線の継ぎ目 (末尾→先頭) は近似保証の対象外のため検証しない。
+///       終了条件③ (max_depth) で停止した辺は超過しうるため、max_depth が
+///       十分大きい呼び出しに対してのみ使用する。
+void ExpectEdgesWithinEps(const ICurve& curve, const PolygonData& poly,
+                          double eps) {
+    const auto segs = curve.GetLinearSegments();
+    const auto [t_min, t_max] = curve.GetParameterRange();
+    const size_t n = poly.curve_params.size();
+    for (size_t i = 0; i + 1 < n; ++i) {
+        const double a = poly.curve_params[i];
+        const double b = poly.curve_params[i + 1];
+        // 直線部に完全に含まれる辺は中点判定の対象外 (終了条件①)
+        bool in_linear = false;
+        for (const auto& s : segs) {
+            if (s[0] <= a && b <= s[1]) { in_linear = true; break; }
+        }
+        if (in_linear) continue;
+
+        const double m = 0.5 * (a + b);
+        const Vector3d pa = curve.GetPointAt(std::clamp(a, t_min, t_max));
+        const Vector3d pb = curve.GetPointAt(std::clamp(b, t_min, t_max));
+        const Vector3d pm = curve.GetPointAt(std::clamp(m, t_min, t_max));
+        const double d = i_ent::PointLineDistance(pm, pa, pb);
+        EXPECT_LE(d, eps + 1e-9) << "edge " << i << " midpoint deviates " << d;
+    }
+}
+
+/// @brief 出力多角形のフィンガープリント (特性化用の集約スカラー)
+struct Fingerprint {
+    int count;
+    double sum_param, min_param, max_param;
+    Vector3d centroid;
+};
+
+/// @brief 多角形からフィンガープリントを計算する
+Fingerprint ComputeFingerprint(const PolygonData& p) {
+    Fingerprint f{p.Count(), 0.0, std::numeric_limits<double>::infinity(),
+                  -std::numeric_limits<double>::infinity(), Vector3d::Zero()};
+    for (double u : p.curve_params) {
+        f.sum_param += u;
+        f.min_param = std::min(f.min_param, u);
+        f.max_param = std::max(f.max_param, u);
+    }
+    for (const auto& v : p.vertices) f.centroid += v;
+    if (!p.vertices.empty()) {
+        f.centroid /= static_cast<double>(p.vertices.size());
+    }
+    return f;
+}
+
+}  // namespace
+
+
+
+/**
+ * 正常系・代表値
+ */
+
+// 線分 (直線部報告なし): 中点距離0で即時終了 (終了条件②) → 端点のみ
+TEST(PolygonalApproximationTest, LineSegment_EmptyPolygons_ReturnsEndpoints) {
+    const auto curve = MakeLineSegment();
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-3);
+    ASSERT_EQ(poly.Count(), 2);
+    EXPECT_NEAR(poly.curve_params[0], 0.0, kParamTol);
+    EXPECT_NEAR(poly.curve_params[1], 1.0, kParamTol);
+    ExpectStructurallyValid(*curve, poly);
+}
+
+// 直線 NURBS (直線部報告あり): 区間全体が直線部に内包 (終了条件①) → 端点のみ
+TEST(PolygonalApproximationTest, StraightNurbs_ShortCircuitsLinearSegment) {
+    const auto curve = MakeStraightNurbs();
+    ASSERT_FALSE(curve->GetLinearSegments().empty());
+    // eps を微小にしても直線部短絡により中間頂点は生成されない
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-6);
+    ASSERT_EQ(poly.Count(), 2);
+    EXPECT_NEAR(poly.curve_params[0], 0.0, kParamTol);
+    EXPECT_NEAR(poly.curve_params[1], 1.0, kParamTol);
+    ExpectStructurallyValid(*curve, poly);
+}
+
+// 半円: 各辺の中点距離が eps 以内 (近似精度の核心)
+TEST(PolygonalApproximationTest, HalfCircle_EachEdgeMidpointWithinEps) {
+    const auto curve = MakeHalfCircle();
+    const double eps = 1e-3;
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), eps);
+    EXPECT_GE(poly.Count(), 3);
+    ExpectStructurallyValid(*curve, poly);
+    ExpectEdgesWithinEps(*curve, poly, eps);
+    // 全頂点が単位円上にあること (独立な正しさの確認)
+    for (const auto& v : poly.vertices) EXPECT_NEAR(v.norm(), 1.0, kEvalTol);
+}
+
+// 混在閉ループ: 実 insc/circ を与えた出力が構造的に妥当
+TEST(PolygonalApproximationTest, ArchBandLoop_StructurallyValid) {
+    const std::vector<std::pair<std::string, std::shared_ptr<ICurve>>> loops = {
+        {"ArchBand1", i_test::MakeLoopArchBand1()},
+        {"ArchBand2", i_test::MakeLoopArchBand2()}};
+    for (const auto& [name, curve] : loops) {
+        SCOPED_TRACE("Loop: " + name);
+        auto [circ, insc] = ExtremalPair(*curve);
+        const auto poly = Approx(*curve, insc, circ, 1e-3);
+        ExpectStructurallyValid(*curve, poly);
+        EXPECT_GE(poly.Count(), 3);
+    }
+}
+
+// 固定点保存: insc/circ の on_curve パラメータは全て出力に含まれる
+TEST(PolygonalApproximationTest, ArchBandLoop_PreservesFixedParams) {
+    const auto curve = i_test::MakeLoopArchBand1();
+    auto [circ, insc] = ExtremalPair(*curve);
+    const auto poly = Approx(*curve, insc, circ, 1e-3);
+    const auto [t_min, t_max] = curve->GetParameterRange();
+
+    for (const auto* pd : {&insc, &circ}) {
+        for (size_t i = 0; i < pd->vertices.size(); ++i) {
+            if (!pd->on_curve[i]) continue;
+            const double p = pd->curve_params[i];
+            // 閉曲線では末尾 t_max が除去されうるため対象外
+            if (curve->IsClosed() && std::abs(p - t_max) < 1e-9) continue;
+            bool found = false;
+            for (double q : poly.curve_params) {
+                if (std::abs(q - p) < 1e-9) { found = true; break; }
+            }
+            EXPECT_TRUE(found) << "fixed param " << p << " missing from output";
+        }
+    }
+}
+
+// 空 insc/circ: 開曲線でも例外なく離散化される (ヘッダ記載の挙動)
+TEST(PolygonalApproximationTest, EmptyPolygons_AcceptedOnOpenCurve) {
+    const auto curve = MakeHalfCircle();
+    PolygonData poly;
+    EXPECT_NO_THROW(poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-2));
+    ExpectStructurallyValid(*curve, poly);
+    EXPECT_GE(poly.Count(), 2);
+}
+
+
+
+/**
+ * 正常系・境界値
+ */
+
+// 巨大 eps: 全区間が即時に距離判定を満たし固定点のみ残る
+TEST(PolygonalApproximationTest, HalfCircle_HugeEps_NoInteriorVertices) {
+    const auto curve = MakeHalfCircle();
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e9);
+    ASSERT_EQ(poly.Count(), 2);
+    EXPECT_NEAR(poly.curve_params[0], 0.0, kParamTol);
+    EXPECT_NEAR(poly.curve_params[1], kPi, kParamTol);
+}
+
+// eps を小さくすると頂点数は単調に増える (非減少)
+TEST(PolygonalApproximationTest, HalfCircle_SmallerEps_RefinesMonotonically) {
+    const auto curve = MakeHalfCircle();
+    const auto coarse = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-1);
+    const auto fine = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-3);
+    EXPECT_GE(fine.Count(), coarse.Count());
+}
+
+// max_depth=0: 距離判定を必ず失敗させ終了条件③を誘発 → 中点1点だけ追加
+TEST(PolygonalApproximationTest, HalfCircle_MaxDepthZero_AddsSingleMidpoint) {
+    const auto curve = MakeHalfCircle();
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-12, 0);
+    ASSERT_EQ(poly.Count(), 3);
+    EXPECT_NEAR(poly.curve_params[0], 0.0, kParamTol);
+    EXPECT_NEAR(poly.curve_params[1], kPi / 2.0, kParamTol);
+    EXPECT_NEAR(poly.curve_params[2], kPi, kParamTol);
+    ExpectStructurallyValid(*curve, poly);
+}
+
+
+
+/**
+ * 正常系・退化
+ */
+
+// 全円 (閉): 末尾 t_max (= t_min と同一点) が除去される
+TEST(PolygonalApproximationTest, FullCircle_DropsTrailingDuplicate) {
+    const auto curve = MakeFullCircle();
+    ASSERT_TRUE(curve->IsClosed());
+    const auto [t_min, t_max] = curve->GetParameterRange();
+    const auto poly = Approx(*curve, EmptyPolygon(), EmptyPolygon(), 1e-2);
+    EXPECT_GE(poly.Count(), 3);
+    // 末尾パラメータが t_max でないこと (重複点が除去済み)
+    EXPECT_GT(std::abs(poly.curve_params.back() - t_max), 1e-9)
+            << "trailing t_max not removed";
+    // 先頭と末尾の頂点が異なること
+    EXPECT_GT((poly.vertices.front() - poly.vertices.back()).norm(), 1e-6);
+    ExpectStructurallyValid(*curve, poly);
+}
+
+// 固定点が範囲外: clamp により例外なく評価され、生パラメータは保持される
+// (高速化での点再利用が境界クランプ挙動を崩さないことのロック)
+TEST(PolygonalApproximationTest, FixedParamOutsideRange_ClampsWithoutThrow) {
+    const auto curve = MakeHalfCircle();
+    const auto [t_min, t_max] = curve->GetParameterRange();
+    // on_curve パラメータをわずかに範囲外へ置いた内包多角形を手構成する
+    PolygonData insc;
+    insc.vertices = {Vector3d(0.0, 0.0, 0.0), Vector3d(0.0, 0.0, 0.0)};
+    insc.on_curve = {true, true};
+    insc.curve_params = {t_min - 1e-9, t_max + 1e-9};
+
+    PolygonData poly;
+    ASSERT_NO_THROW(poly = Approx(*curve, insc, EmptyPolygon(), 1e-2));
+    ExpectStructurallyValid(*curve, poly);
+    // 生パラメータは範囲外のまま保持され、頂点は端点へクランプ評価される
+    EXPECT_NEAR(poly.curve_params.front(), t_min - 1e-9, kParamTol);
+    EXPECT_NEAR(poly.curve_params.back(), t_max + 1e-9, kParamTol);
+    EXPECT_LE((poly.vertices.front() - curve->GetPointAt(t_min)).norm(), kEvalTol);
+    EXPECT_LE((poly.vertices.back() - curve->GetPointAt(t_max)).norm(), kEvalTol);
+}
+
+
+
+/**
+ * 特性化フィンガープリント採取 (非決定論的ケースの基準値取得用)
+ *
+ * 既定では無効。高速化リファクタの前後で出力不変を確認したい場合は
+ * --gtest_also_run_disabled_tests で実行し、出力された (count, sum/min/max
+ * param, centroid) を比較する。
+ */
+TEST(PolygonalApproximationTest, DISABLED_RecordFingerprints) {
+    struct Case {
+        std::string name;
+        std::shared_ptr<ICurve> curve;
+        bool closed_loop;  // true なら ExtremalPair で insc/circ を生成
+        double eps;
+    };
+    std::vector<Case> cases = {
+        {"HalfCircle@1e-3", MakeHalfCircle(), false, 1e-3},
+        {"ArchBand1@1e-3", i_test::MakeLoopArchBand1(), true, 1e-3},
+        {"ArchBand2@1e-3", i_test::MakeLoopArchBand2(), true, 1e-3}};
+
+    for (const auto& c : cases) {
+        PolygonData insc, circ;
+        if (c.closed_loop) std::tie(circ, insc) = ExtremalPair(*c.curve);
+        const auto poly = Approx(*c.curve, insc, circ, c.eps);
+        const auto f = ComputeFingerprint(poly);
+        std::cout << "[fingerprint] " << c.name
+                  << " count=" << f.count
+                  << " sum=" << f.sum_param
+                  << " min=" << f.min_param
+                  << " max=" << f.max_param
+                  << " centroid=(" << f.centroid.x() << ", "
+                  << f.centroid.y() << ", " << f.centroid.z() << ")\n";
+    }
+}

--- a/tests/entities/test_entity_parameter_data.cpp
+++ b/tests/entities/test_entity_parameter_data.cpp
@@ -8,8 +8,11 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <vector>
 
 #include "igesio/common/errors.h"
+#include "igesio/common/iges_metadata.h"
+#include "igesio/common/serialization.h"
 #include "igesio/entities/pd.h"
 
 namespace {
@@ -94,4 +97,76 @@ TEST(ToRawEntityPDTest, NormalCase) {
                      {"1", "1", "1", "0", "1", "0", "0.", "0.", "1.", "1.",
                       "1.", "1.", "1.", "1.", "0.", "0.", "1.", "0.", "0.",
                       "1.", "0.", "0.", "1."});
+}
+
+
+
+/******************************************************************************
+ * ToIGESParameterVectorの型分類のテスト
+ *
+ * pd.dataの各文字列を内容ヒューリスティック(ClassifyParameter)で型推定し、
+ * 整数→実数→文字列→言語ステートメントの順にフォールバック変換する。
+ * ここでは get_format(i).type が期待どおりに分類されるかを検証する。
+ *****************************************************************************/
+
+namespace {
+
+/// @brief 与えた文字列列をpd.dataに持つRawEntityPDを変換する
+/// @param data パラメータ文字列の列
+/// @return 分類・変換済みのIGESParameterVector
+/// @note typeは分類に影響しないためkNullを用いる
+igesio::IGESParameterVector ClassifyParameters(
+        const std::vector<std::string>& data) {
+    return i_ent::ToIGESParameterVector(
+            i_ent::RawEntityPD(i_ent::EntityType::kNull, data));
+}
+
+}  // namespace
+
+// 整数形式("123"/"+5"/"-7")はInteger型に分類される
+TEST(ToIGESParameterVectorTest, ClassifiesInteger) {
+    const auto v = ClassifyParameters({"123", "+5", "-7"});
+    ASSERT_EQ(v.size(), 3u);
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v.get_format(i).type, igesio::IGESParameterType::kInteger)
+                << "index " << i;
+    }
+}
+
+// 実数形式(".5"や指数部D/Eを含む)はReal型に分類される
+TEST(ToIGESParameterVectorTest, ClassifiesReal) {
+    const auto v = ClassifyParameters({"1.5", ".5", "1E-08", "1.0D+01"});
+    ASSERT_EQ(v.size(), 4u);
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v.get_format(i).type, igesio::IGESParameterType::kReal)
+                << "index " << i;
+    }
+}
+
+// Hollerith形式("5Hhello"/"2HUM")はString型に分類される
+TEST(ToIGESParameterVectorTest, ClassifiesString) {
+    const auto v = ClassifyParameters({"5Hhello", "2HUM"});
+    ASSERT_EQ(v.size(), 2u);
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v.get_format(i).type, igesio::IGESParameterType::kString)
+                << "index " << i;
+    }
+}
+
+// 'D'を含み実数と誤推定されるが、変換に失敗してLanguage Statementへフォールバックする
+TEST(ToIGESParameterVectorTest, FallsBackToLanguageStatement) {
+    const auto v = ClassifyParameters({"DEGREE", "SOLIDWORKS"});
+    ASSERT_EQ(v.size(), 2u);
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v.get_format(i).type,
+                  igesio::IGESParameterType::kLanguageStatement) << "index " << i;
+    }
+}
+
+// 空パラメータはデフォルト値のString型として扱われる
+TEST(ToIGESParameterVectorTest, EmptyParameterIsDefaultString) {
+    const auto v = ClassifyParameters({""});
+    ASSERT_EQ(v.size(), 1u);
+    EXPECT_EQ(v.get_format(0).type, igesio::IGESParameterType::kString);
+    EXPECT_TRUE(v.get_format(0).is_default);
 }

--- a/tests/models/test_assembly.cpp
+++ b/tests/models/test_assembly.cpp
@@ -6,7 +6,7 @@
  * @copyright 2026 Yayoi Habami
  *
  * テスト対象 (Assembly):
- *   - エンティティ管理: AddEntity / GetEntity / GetEntityCount /
+ *   - エンティティ管理: AddEntity / AddEntities / GetEntity / GetEntityCount /
  *                       AreAllReferencesSet / GetUnresolvedReferences /
  *                       IsReady / Validate
  *   - ツリー: AddChildAssembly / GetParent / GetChildAssemblies / Root /
@@ -222,6 +222,118 @@ TEST_F(AssemblyTest, References_ResolveRegardlessOfAddOrder) {
         backward.AddEntity(*it);
     }
     EXPECT_TRUE(backward.AreAllReferencesSet());
+}
+
+
+
+/**
+ * エンティティ管理 (AddEntities: 一括追加)
+ *
+ * NOTE: Entities()はAddEntities経由でロード済み(reader.cpp)であり、各エンティティの
+ *       参照ポインタは設定済みである。そのためAddEntities内部の参照解決ループ自体は
+ *       no-opとなり、ここで検証するのはAssemblyの未解決判定(メンバシップ条件)という
+ *       観測可能な契約である。AddEntityループとの等価性(MatchesPerEntityAddEntity)が
+ *       最も強い保証となる。
+ */
+
+// 全件を一括追加すると、件数と各GetEntityが整合する
+TEST_F(AssemblyTest, AddEntities_StoresAllAndIsCountConsistent) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+
+    Assembly node;
+    node.AddEntities(ents);
+    EXPECT_EQ(node.GetEntityCount(), ents.size());
+    for (const auto& e : ents) {
+        EXPECT_EQ(node.GetEntity(e->GetID()), e);
+    }
+}
+
+// 相互参照する全件を一括追加すると、全参照が解決する
+TEST_F(AssemblyTest, AddEntities_ResolvesAllReferences) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+
+    Assembly node;
+    node.AddEntities(ents);
+    EXPECT_TRUE(node.AreAllReferencesSet());
+    EXPECT_TRUE(node.GetUnresolvedReferences().empty());
+}
+
+// 参照先が参照元より後ろに来る並び(前方参照を含む)でも、1パスで双方向に解決する
+TEST_F(AssemblyTest, AddEntities_ResolvesForwardAndBackwardReferences) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+    // ベクタを逆順にし、前方参照を含む並びにする (バッチ解決の順序非依存を確認)
+    std::vector<EntityPtr> reversed(ents.rbegin(), ents.rend());
+
+    Assembly node;
+    node.AddEntities(reversed);
+    EXPECT_TRUE(node.AreAllReferencesSet());
+    EXPECT_TRUE(node.GetUnresolvedReferences().empty());
+}
+
+// 同じ集合をAddEntitiesとAddEntityループで追加した結果が一致する (Option Bの肝)
+TEST_F(AssemblyTest, AddEntities_MatchesPerEntityAddEntity) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+
+    Assembly batch;
+    batch.AddEntities(ents);
+
+    Assembly loop;
+    for (const auto& e : ents) loop.AddEntity(e);
+
+    EXPECT_EQ(batch.GetEntityCount(), loop.GetEntityCount());
+    EXPECT_EQ(batch.AreAllReferencesSet(), loop.AreAllReferencesSet());
+    EXPECT_EQ(batch.GetUnresolvedReferences(), loop.GetUnresolvedReferences());
+}
+
+// 一括追加後、ルート逆引きインデックスが機能する (RegisterInIndex実行の確認)
+TEST_F(AssemblyTest, AddEntities_RegistersInRootIndex) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+    auto pair = FindReferencingPair(data_->Root());
+    ASSERT_TRUE(pair.has_value());
+
+    Assembly node;
+    node.AddEntities(ents);
+
+    // 全エンティティがFindOwnerで自ノードに解決される
+    for (const auto& e : ents) {
+        EXPECT_EQ(node.FindOwner(e->GetID()), &node);
+    }
+    // FindReferrersがreferentに対しreferrerを返す
+    const auto referrers = node.FindReferrers(pair->second);
+    EXPECT_NE(std::find(referrers.begin(), referrers.end(), pair->first),
+              referrers.end());
+}
+
+// nullptrを含むベクタの一括追加で例外
+TEST_F(AssemblyTest, AddEntities_ThrowsInvalidArgumentWhenNullPresent) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+    const std::vector<EntityPtr> with_null = {ents[0], nullptr};
+
+    Assembly node;
+    EXPECT_THROW(node.AddEntities(with_null), std::invalid_argument);
+}
+
+// 空ベクタの一括追加は例外を投げず、件数を変えない
+TEST_F(AssemblyTest, AddEntities_EmptyVectorIsNoOp) {
+    auto ents = Entities();
+    ASSERT_FALSE(ents.empty());
+
+    // 空ノードへの空追加
+    Assembly empty_node;
+    EXPECT_NO_THROW(empty_node.AddEntities({}));
+    EXPECT_EQ(empty_node.GetEntityCount(), 0u);
+
+    // 既存エンティティを持つノードへの空追加は件数不変
+    Assembly populated;
+    populated.AddEntity(ents[0]);
+    EXPECT_NO_THROW(populated.AddEntities({}));
+    EXPECT_EQ(populated.GetEntityCount(), 1u);
 }
 
 

--- a/tests/utils/test_iges_string_utils_line_assertion.cpp
+++ b/tests/utils/test_iges_string_utils_line_assertion.cpp
@@ -536,3 +536,33 @@ TEST(ParseFreeFormattedDataTest, ErrorCase) {
     EXPECT_THROW(i_util::ParseFreeFormattedData(lines, ',', ';'),
                  igesio::SectionFormatError);
 }
+
+// 宣言長0のHollerith("0H...")は非H文字列として分割する
+TEST(ParseFreeFormattedDataTest, ZeroLengthHollerith) {
+    // "0H"をH文字列(宣言長0)として扱うと'X'手前で切れ「終端の後ろに区切り文字
+    // がない」エラーになる。宣言長0は非H扱いとするのが正しい挙動。
+    std::vector<std::string> lines = {"0HX,1;"};
+    std::vector<std::string> expected = {"0HX", "1"};
+    EXPECT_EQ(i_util::ParseFreeFormattedData(lines, ',', ';'), expected);
+}
+
+// パラメータが1つだけのレコード("5;")
+TEST(ParseFreeFormattedDataTest, SingleParameterRecord) {
+    std::vector<std::string> lines = {"5;"};
+    std::vector<std::string> expected = {"5"};
+    EXPECT_EQ(i_util::ParseFreeFormattedData(lines, ',', ';'), expected);
+}
+
+// 区切り文字直後の先頭空白は除去される
+TEST(ParseFreeFormattedDataTest, LeadingSpacesAfterDelimiterTrimmed) {
+    std::vector<std::string> lines = {"1,  2,   3;"};
+    std::vector<std::string> expected = {"1", "2", "3"};
+    EXPECT_EQ(i_util::ParseFreeFormattedData(lines, ',', ';'), expected);
+}
+
+// レコード区切り文字が存在しない場合はSectionFormatError
+TEST(ParseFreeFormattedDataTest, ThrowsSectionFormatErrorWhenNoRecordDelimiter) {
+    std::vector<std::string> lines = {"1,2,3"};
+    EXPECT_THROW(i_util::ParseFreeFormattedData(lines, ',', ';'),
+                 igesio::SectionFormatError);
+}


### PR DESCRIPTION
Reading NURBS-heavy IGES files spent most of its time in avoidable work rather than in actual geometry construction: exception-driven type detection during parsing, O(L²) free-format scanning, O(N²) DE↔PD matching and reference resolution, a deep copy per record, per-parameter string allocations in numeric conversion, and a heavy per-surface domain precompute left to run serially at first query. None of this is inherent to parsing IGES — it is wasted work on the hot path.

This branch makes the read pipeline **fast by doing less, not by doing it differently**:

- **Same bytes out.** Every replaced hot path produces byte-for-byte identical results and the same exception types for valid input; only wasted work is removed. Conformant files load to exactly the same model.
- **Stop throwing on the hot path.** Type detection no longer probes parsers by catching their exceptions — it classifies from content first, so correctly-typed data never unwinds the stack.
- **Linear, not quadratic.** O(L²) free-format scans and O(N²) DE↔PD matching / reference resolution become single-pass cursors and direct map lookups.
- **Allocate and copy less.** Range-based, exception-free numeric conversion; PD records taken by reference and `move`d instead of deep-copied; line buffers reserved and moved out.
- **Use all the cores.** The heavy per-surface containment-polygon precompute is fanned out across hardware threads at the end of the read, behind a standard-library-only parallel helper, and the precompute itself is de-duplicated so each curve point is evaluated once.

### Key Changes

#### 1. Content-based parameter typing — kill the exception storm (`pd.cpp`)

- `ToIGESParameterVector` previously tried integer→real→string parsers and *caught* the failures, so every real threw once and every string threw twice — tens of thousands of stack unwinds on a NURBS file.
- Add `ClassifyParameter` to infer the type from the parameter's content in one pass, then start from the inferred parser and `[[fallthrough]]` through the rest in the original int→real→string→language order. Skipped parsers would have thrown for that input anyway, so results are unchanged; only a rare Language token containing `'E'`/`'D'` still costs one fallback throw.
- Carried fix (`38dbf4b`): a real written without an integer part (`".5"`) is now reachable as `kReal` under content classification, so `FromIgesRealWithFormat` accepts `'.'` as a valid first character (its signed form `"-.5"` already passed — an asymmetry).

#### 2. Linear free-format parsing (`iges_string_utils.cpp`)

- `GetParameterString` copied the whole remainder every iteration (`rest.substr(1)`), re-scanned from the front, and searched for `'H'` across the entire remainder on H-free numeric data — all O(L²).
- Replace with a cursor advancing over a single connected buffer (reserved up front); new `FindParameterEnd` derives a Hollerith end from its declared length and otherwise scans to the next delimiter with `find_first_of`. Also fixes a prior `int eop` vs `npos` (`size_t`) comparison by using `std::size_t` throughout. Exception types are unchanged.

#### 3. Allocation-free, throw-free numeric conversion (`serialization.cpp`)

- `FromIgesIntegerWithFormat`: parse with `std::from_chars` over a `[first,last]` range — no trim allocation, no exceptions; explicitly reject a lone sign / trailing junk (`"+-42"`) and map `result_out_of_range` to `TypeConversionError`.
- `FromIgesRealWithFormat`: parse with `std::strtod` directly on the buffer (libstdc++ on MinGW has no `from_chars<double>`), converting `D`→`E` only for the rare `'D'`-exponent case; detect `ERANGE` via `errno`, keep the subnormal-underflow check, reject malformed signs.
- Replace `IsSinglePrecision`/`HasIntegerPart`/`HasFractionPart`/`HasExponentPart` (four separate `find` scans) with one `AnalyzeRealFormat` pass producing a `RealFormatInfo`.

#### 4. Direct DE↔PD matching and batch entity insertion (`reader.cpp`, `assembly.{h,cpp}`, `pd.{h,cpp}`)

- Build a `sequence_number → index` map once (O(N), first-wins to preserve the old `find_if` duplicate behavior) and look each DE up directly instead of a linear scan per DE; take the matched PD by `const&` instead of copying the whole `RawEntityPD` per entity.
- Add `Assembly::AddEntities(vector)`: register every entity into the map and root index, then resolve references once (O(entities + refs)), avoiding the per-insert full scan of repeated `AddEntity`. The reader collects created entities and calls it once; existing `AddEntity` is untouched.
- Add a `ToRawEntityPD` overload taking the already-known DE pointer and sequence number so the hot path skips re-extracting them; `ParseFreeFormattedData` gains a `data_part_width` argument so raw lines are truncated to the data column in place (removing a per-line `GetDataPart` substring); `iges_binary_reader`'s `ReadToNextLineBreak` returns a reserved `std::string` that `GetLine` moves out, instead of building a `vector<char>` and copying it.
- Carried fix (`ee4c3e6`): `RawEntityPD` copy/move now propagate `data_types`, which was previously dropped — silently losing per-parameter type info when a record was copied.

#### 5. Parallel geometry-cache pre-build during read (`common/parallel.h`, `entity_base.h`, `assembly.{h,cpp}`, `reader.{h,cpp}`, `trimmed_surface.{h,cpp}`)

- A `TrimmedSurface` defers its domain (containment-polygon) cache until first queried; for files with many trimmed surfaces that lazy work is heavy and otherwise runs serially on the main thread at render/query time. Pre-compute these caches at the end of the read, fanned across cores.
- New header-only `ParallelFor` / `ParallelForEach` built on `std::async`/`std::future` only — no `<execution>`, no OpenMP — so they work across GCC/Clang/MSVC on Linux/macOS/Windows. They split into one contiguous chunk per hardware thread (last chunk on the calling thread), join before returning, re-throw the first worker exception, and fall back to serial below a threshold or when `hardware_concurrency() <= 1`. CMake links `Threads::Threads`.
- Add `EntityBase::PrepareGeometryCache()` (virtual, default no-op; contract: called at most once per entity, never concurrently for the same entity); `TrimmedSurface` overrides it to call `BuildDomainCache()`. `Assembly::PrepareGeometryCaches(recursive = true)` `ParallelForEach`es over the entities — each touches only its own cache, so no locking is needed.
- `ConvertFromIntermediate` / `ReadIges` gain a `prepare_caches` flag (default `true`); when set, the parallel pre-compute runs once after reference resolution and structure are finalized.
- Carried fix (`4bc1a5e`): add `-fprofile-update=atomic` to the GCC coverage build so gcov counters are race-free now that the read runs multi-threaded (`geninfo: Unexpected negative count '-1'`).

#### 6. De-duplicate the containment-polygon precompute (`extremal_polygon.{h,cpp}`, `polygonal_approximation.cpp`, `algorithms.cpp`)

- Building a `TrimmedSurface`'s containment polygons re-did circumscribed/inscribed-independent work and re-evaluated curve points already computed — now the dominant per-surface cost at read time.
- Split `ComputeExtremalPolygon` into `PrepareExtremalPolygonData` (the shared prep: sampling, curve-property/orientation check, plane basis, 2D projection, initial samples) and `RefineExtremalPolygon` (the per-polygon subdivision loop). Add `ComputeExtremalPolygonPair`, which runs the prep once and refines both polygons; `ComputeContainmentPolygons` calls it. Result matches the separate calls.
- In `SubdivideWithParams`, introduce `ParamPoint` (param + optional already-evaluated point) and `Interval` (carries the parent's endpoint evaluations) so child intervals inherit the parent's outer-endpoint and midpoint points — only the new midpoint is evaluated per interval, and `PolygonData` construction reuses the cached points instead of re-calling `GetPointAt` for everything.

### Tests

- `test_parallel.cpp`: `ParallelFor` / `ParallelForEach` coverage (chunking, serial fallback, exception propagation).
- `test_polygonal_approximation.cpp` (new): subdivision + point-reuse path.
- `test_assembly.cpp`: `AddEntities` stores all entities with consistent count, resolves forward/backward refs in one pass regardless of order, matches the per-entity `AddEntity` result, registers in the root index, throws on a null element, no-ops on empty.
- `test_entity_parameter_data.cpp`: `ToIGESParameterVector` classification — integers → `kInteger`; reals including `".5"` and D/E exponents → `kReal`; Hollerith → `kString`; tokens mis-inferred as real then failing (`"DEGREE"`/`"SOLIDWORKS"`) fall back to `kLanguageStatement`; empty parameter stays default `kString`.
- `test_iges_string_utils_line_assertion.cpp`: zero-length Hollerith (`"0HX"`) split as non-H; single-parameter record; leading spaces after a delimiter trimmed; missing record delimiter throws `SectionFormatError`.